### PR TITLE
Fixed remove on eventcontroller

### DIFF
--- a/lib/src/event_controller.dart
+++ b/lib/src/event_controller.dart
@@ -56,6 +56,7 @@ class EventController<T> extends ChangeNotifier {
     for (final e in _events) {
       if (e.year == event.date.year) {
         e.removeEvent(event);
+        _eventList.removeWhere((element) => element.event == event.event);
         notifyListeners();
         break;
       }


### PR DESCRIPTION
When removing events from the EventController, they are not removed from `_eventList`, resulting in removed elements still displaying, at least in the DayView() 