### PR TITLE
Feature: Add titleProvider parameter to views

### DIFF
--- a/lib/src/components/day_view_components.dart
+++ b/lib/src/components/day_view_components.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 import '../constants.dart';
 import '../extensions.dart';
+import '../typedefs.dart';
 import 'common_components.dart';
 
 /// This class defines default tile to display in day view.
@@ -121,6 +122,7 @@ class DayPageHeader extends CalendarPageHeader {
     VoidCallback? onPreviousDay,
     Color iconColor = Constants.black,
     Color backgroundColor = Constants.headerBackground,
+    StringProvider? dateStringBuilder,
     required DateTime date,
   }) : super(
           key: key,
@@ -130,8 +132,10 @@ class DayPageHeader extends CalendarPageHeader {
           onNextDay: onNextDay,
           onPreviousDay: onPreviousDay,
           onTitleTapped: onTitleTapped,
-          dateStringBuilder: DayPageHeader._dayStringBuilder,
+          dateStringBuilder:
+              dateStringBuilder ?? DayPageHeader._dayStringBuilder,
         );
+
   static String _dayStringBuilder(DateTime date, {DateTime? secondaryDate}) =>
       "${date.day} - ${date.month} - ${date.year}";
 }

--- a/lib/src/components/month_view_components.dart
+++ b/lib/src/components/month_view_components.dart
@@ -197,6 +197,7 @@ class MonthPageHeader extends CalendarPageHeader {
     VoidCallback? onPreviousMonth,
     Color iconColor = Constants.black,
     Color backgroundColor = Constants.headerBackground,
+    StringProvider? dateStringBuilder,
     required DateTime date,
   }) : super(
           key: key,
@@ -206,8 +207,10 @@ class MonthPageHeader extends CalendarPageHeader {
           onTitleTapped: onTitleTapped,
           iconColor: iconColor,
           backgroundColor: backgroundColor,
-          dateStringBuilder: MonthPageHeader._monthStringBuilder,
+          dateStringBuilder:
+              dateStringBuilder ?? MonthPageHeader._monthStringBuilder,
         );
+
   static String _monthStringBuilder(DateTime date, {DateTime? secondaryDate}) =>
       "${date.month} - ${date.year}";
 }

--- a/lib/src/components/week_view_components.dart
+++ b/lib/src/components/week_view_components.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../typedefs.dart';
 import 'common_components.dart';
 
 class WeekPageHeader extends CalendarPageHeader {
@@ -13,6 +14,7 @@ class WeekPageHeader extends CalendarPageHeader {
     VoidCallback? onNextDay,
     AsyncCallback? onTitleTapped,
     VoidCallback? onPreviousDay,
+    StringProvider? dateStringBuilder,
     required DateTime startDate,
     required DateTime endDate,
   }) : super(
@@ -22,8 +24,9 @@ class WeekPageHeader extends CalendarPageHeader {
           onNextDay: onNextDay,
           onPreviousDay: onPreviousDay,
           onTitleTapped: onTitleTapped,
-          dateStringBuilder: WeekPageHeader._weekStringBuilder,
+          dateStringBuilder: dateStringBuilder ?? _weekStringBuilder,
         );
+
   static String _weekStringBuilder(DateTime date, {DateTime? secondaryDate}) =>
       "${date.day} / ${date.month} / ${date.year} to "
       "${secondaryDate != null ? "${secondaryDate.day} / "

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -129,6 +129,12 @@ class DayView<T> extends StatefulWidget {
   /// This method will be called when user long press on calendar.
   final DatePressCallback? onDateLongPress;
 
+  /// Defines the String displayed by the default title builder.
+  ///
+  /// Use this parameter instead of [dayTitleBuilder] if you like the behavior
+  /// of the default builder and only need to change the title
+  final String Function(DateTime)? titleProvider;
+
   /// Main widget for day view.
   const DayView({
     Key? key,
@@ -156,8 +162,11 @@ class DayView<T> extends StatefulWidget {
     this.scrollOffset = 0.0,
     this.onEventTap,
     this.onDateLongPress,
+    this.titleProvider,
   })  : assert((timeLineOffset) >= 0,
             "timeLineOffset must be greater than or equal to 0"),
+        assert(dayTitleBuilder == null || titleProvider == null,
+        'Only one of dayTitleBuilder and titleProvider should be set'),
         super(key: key);
 
   @override
@@ -198,6 +207,8 @@ class DayViewState<T> extends State<DayView<T>> {
 
   late VoidCallback _reloadCallback;
 
+  StringProvider? _dateStringBuilder;
+
   @override
   void initState() {
     super.initState();
@@ -233,6 +244,9 @@ class DayViewState<T> extends State<DayView<T>> {
     _timeLineBuilder = widget.timeLineBuilder ?? _defaultTimeLineBuilder;
     _eventTileBuilder = widget.eventTileBuilder ?? _defaultEventTileBuilder;
     _dayTitleBuilder = widget.dayTitleBuilder ?? _defaultDayBuilder;
+    _dateStringBuilder = widget.titleProvider == null
+        ? null
+        : (date, {secondaryDate}) => widget.titleProvider!(date);
   }
 
   @override
@@ -397,6 +411,7 @@ class DayViewState<T> extends State<DayView<T>> {
       date: _currentDate,
       onNextDay: nextPage,
       onPreviousDay: previousPage,
+      dateStringBuilder: _dateStringBuilder,
       onTitleTapped: () async {
         final selectedDate = await showDatePicker(
           context: context,

--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -108,6 +108,12 @@ class MonthView<T> extends StatefulWidget {
   /// This method will be called when user long press on calendar.
   final DatePressCallback? onDateLongPress;
 
+  /// Defines the String displayed by the default title builder.
+  ///
+  /// Use this parameter instead of [headerBuilder] if you like the behavior of
+  /// the default header and only need to change the title
+  final String Function(DateTime)? titleProvider;
+
   /// Main [Widget] to display month view.
   const MonthView({
     Key? key,
@@ -129,7 +135,10 @@ class MonthView<T> extends StatefulWidget {
     this.onCellTap,
     this.onEventTap,
     this.onDateLongPress,
-  }) : super(key: key);
+    this.titleProvider,
+  })  : assert(headerBuilder == null || titleProvider == null,
+            'Only one of headerBuilder and titleProvider should be set'),
+        super(key: key);
 
   @override
   MonthViewState<T> createState() => MonthViewState<T>();
@@ -165,6 +174,8 @@ class MonthViewState<T> extends State<MonthView<T>> {
   bool _controllerAdded = false;
 
   late VoidCallback _reloadCallback;
+
+  StringProvider? _dateStringBuilder;
 
   @override
   void initState() {
@@ -217,6 +228,13 @@ class MonthViewState<T> extends State<MonthView<T>> {
     // This widget will be displayed on top of the page.
     // from where user can see month and change month.
     _headerBuilder = widget.headerBuilder ?? _defaultHeaderBuilder;
+
+    // Used by the default header builder to display a custom title.
+    // We wrap the more natural signature of titleProvider to be a valid
+    // StringProvider
+    _dateStringBuilder = widget.titleProvider == null
+        ? null
+        : (date, {secondaryDate}) => widget.titleProvider!(date);
   }
 
   @override
@@ -359,6 +377,7 @@ class MonthViewState<T> extends State<MonthView<T>> {
       onPreviousMonth: previousPage,
       date: date,
       onNextMonth: nextPage,
+      dateStringBuilder: _dateStringBuilder,
     );
   }
 

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -128,6 +128,12 @@ class WeekView<T> extends StatefulWidget {
   /// This method will be called when user long press on calendar.
   final DatePressCallback? onDateLongPress;
 
+  /// Defines the String displayed by the default page header builder.
+  ///
+  /// Use this parameter instead of [weekPageHeaderBuilder] if you like the
+  /// behavior of the default header and only need to change the title
+  final String Function(DateTime, DateTime)? titleProvider;
+
   /// Main widget for week view.
   const WeekView({
     Key? key,
@@ -157,7 +163,12 @@ class WeekView<T> extends StatefulWidget {
     this.onDateLongPress,
     this.weekDays = WeekDays.values,
     this.showWeekends = true,
-  }) : super(key: key);
+    this.titleProvider,
+  })  : assert(
+            weekPageHeaderBuilder == null || titleProvider == null,
+            'Only one of weekPageHeaderBuilder and'
+            ' titleProvider should be set'),
+        super(key: key);
 
   @override
   WeekViewState<T> createState() => WeekViewState<T>();
@@ -201,6 +212,8 @@ class WeekViewState<T> extends State<WeekView<T>> {
   late ScrollController _scrollController;
   late final List<WeekDays> _weekDays;
 
+  StringProvider? _dateStringBuilder;
+
   @override
   void initState() {
     super.initState();
@@ -208,7 +221,9 @@ class WeekViewState<T> extends State<WeekView<T>> {
     _weekDays = widget.weekDays.toSet().toList();
 
     if (!widget.showWeekends) {
-      _weekDays..remove(WeekDays.saturday)..remove(WeekDays.sunday);
+      _weekDays
+        ..remove(WeekDays.saturday)
+        ..remove(WeekDays.sunday);
     }
 
     assert(
@@ -257,6 +272,10 @@ class WeekViewState<T> extends State<WeekView<T>> {
     _weekHeaderBuilder =
         widget.weekPageHeaderBuilder ?? _defaultWeekPageHeaderBuilder;
     _weekDayBuilder = widget.weekDayBuilder ?? _defaultWeekDayBuilder;
+    _dateStringBuilder = widget.titleProvider == null
+        ? null
+        : (date, {secondaryDate}) =>
+            widget.titleProvider!(date, secondaryDate!);
   }
 
   @override
@@ -460,6 +479,7 @@ class WeekViewState<T> extends State<WeekView<T>> {
       endDate: _currentEndDate,
       onNextDay: nextPage,
       onPreviousDay: previousPage,
+      dateStringBuilder: _dateStringBuilder,
       onTitleTapped: () async {
         final selectedDate = await showDatePicker(
           context: context,


### PR DESCRIPTION
Hello,

The purpose of this PR is to add the ability to customize the string displayed in the header of DayView/WeekView/MonthView.
This is especially useful when the client application wants to add localization to the way the dates are displayed without having to implement again all the actions supported by the default header components (like jumping to another date).

I only noticed once I made these changes that there is already a PR with the same goal ( #36 ).
There are two main differences between this PR and #36:
- this PR also supports `WeekView` and `MonthView`;
- the signature of the parameter matches the number of dates available to the view (one for day and month, two for week), which seems like a more natural API. The components' states are responsible for wrapping it in an actual StringProvider.

Have a nice day!