### PR TITLE
fix: Display LiveTimeIndicator in foreground

### DIFF
--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -109,14 +109,6 @@ class InternalDayViewPage<T> extends StatelessWidget {
               showVerticalLine: showVerticalLine,
             ),
           ),
-          if (showLiveLine && liveTimeIndicatorSettings.height > 0)
-            LiveTimeIndicator(
-              liveTimeIndicatorSettings: liveTimeIndicatorSettings,
-              width: width,
-              height: height,
-              heightPerMinute: heightPerMinute,
-              timeLineWidth: timeLineWidth,
-            ),
           PressDetector(
             width: width,
             height: height,
@@ -147,6 +139,16 @@ class InternalDayViewPage<T> extends StatelessWidget {
             timeLineOffset: timeLineOffset,
             timeLineWidth: timeLineWidth,
             key: ValueKey(heightPerMinute),
+          ),
+          if (showLiveLine && liveTimeIndicatorSettings.height > 0)
+            IgnorePointer(
+              child: LiveTimeIndicator(
+              liveTimeIndicatorSettings: liveTimeIndicatorSettings,
+              width: width,
+              height: height,
+              heightPerMinute: heightPerMinute,
+              timeLineWidth: timeLineWidth,
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
LiveTimeIndicator was defined in a Stack, prior to Event tiles.
Thus it was displayed in background.
I moved the LiveTimeIndicator after the EventGenerator in the stack children.

I also added a IgnorePointer widget, since the LiveTimeIndicator Widget takes the whole agenda, if it catches gestures, event tiles cannot be pressed anymore.


Before:

![before](https://user-images.githubusercontent.com/8408045/165514812-46d40062-589a-4856-8e6a-781abcf020e0.png)

After: 

![after](https://user-images.githubusercontent.com/8408045/165514846-a3a1b73c-ee36-452a-b0b0-252927835eda.png)

