### PR TITLE
Show correct day's events in DayView 

### DIFF
--- a/lib/src/event_controller.dart
+++ b/lib/src/event_controller.dart
@@ -96,6 +96,16 @@ class EventController<T extends Object?> extends ChangeNotifier {
     }
   }
 
+  /// Removes multiple [event] from this controller.
+  void removeWhere(bool Function(CalendarEventData<T> element) test) {
+    for (final e in _events.values) {
+      e.removeWhere(test);
+    }
+    _rangingEventList.removeWhere(test);
+    _eventList.removeWhere(test);
+    notifyListeners();
+  }
+
   /// Returns events on given day.
   ///
   /// To overwrite default behaviour of this function,
@@ -163,5 +173,5 @@ class EventController<T extends Object?> extends ChangeNotifier {
     notifyListeners();
   }
 
-  //#endregion
+//#endregion
 }

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -30,8 +30,10 @@ extension DateTimeExtensions on DateTime {
   }
 
   /// Gets difference of days between [date] and calling object.
-  int getDayDifference(DateTime date) =>
-      withoutTime.difference(date.withoutTime).inDays.abs();
+  int getDayDifference(DateTime date) => DateTime.utc(year, month, day)
+      .difference(DateTime.utc(date.year, date.month, date.day))
+      .inDays
+      .abs();
 
   /// Gets difference of weeks between [date] and calling object.
   int getWeekDifference(DateTime date, {WeekDays start = WeekDays.monday}) =>


### PR DESCRIPTION
Solve Issues #97 and #80 by comparing DateTime object in UTC and not in local time, to avoid Daylight Saving Time disalignment when using DateTime.difference() and Duration.inDays() combination