### PR TITLE
Set _currentWeek in _onPageChange

### DIFF
--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -589,6 +589,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
         );
         _currentEndDate = _currentStartDate.add(Duration(days: 6));
         _currentIndex = index;
+        _currentWeek = _currentStartDate;
       });
     }
     widget.onPageChange?.call(_currentStartDate, _currentIndex);


### PR DESCRIPTION
Setting the state in a widget higher up the hierarchy from **WeekView** which will cause **_regulateCurrentDate** to execute and set the start date from the last-set **_currentWeek**, which is only changed if the week goes out of bounds, not when the page changes.