### PR TITLE
Support for custom detector, enable custom physics and fix for #97, #80 by @francescovgg

### DIFF
--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -33,6 +33,9 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
   /// A builder that builds time line.
   final DateWidgetBuilder timeLineBuilder;
 
+  /// Builds custom PressDetector widget
+  final DetectorBuilder dayDetectorBuilder;
+
   /// Settings for hour indicator lines.
   final HourIndicatorSettings hourIndicatorSettings;
 
@@ -100,6 +103,7 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
     required this.onDateLongPress,
     required this.minuteSlotSize,
     required this.scrollNotifier,
+    required this.dayDetectorBuilder,
   }) : super(key: key);
 
   @override
@@ -120,12 +124,11 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
               showVerticalLine: showVerticalLine,
             ),
           ),
-          PressDetector(
+          dayDetectorBuilder(
             width: width,
             height: height,
             heightPerMinute: heightPerMinute,
             date: date,
-            onDateLongPress: onDateLongPress,
             minuteSlotSize: minuteSlotSize,
           ),
           Align(

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -145,6 +145,12 @@ class DayView<T extends Object?> extends StatefulWidget {
   /// where events are not there.
   final MinuteSlotSize minuteSlotSize;
 
+  /// Use this field to disable the calendar scrolling
+  final ScrollPhysics? scrollPhysics;
+
+  /// Use this field to disable the page view scrolling behavior
+  final ScrollPhysics? pageViewPhysics;
+
   /// Main widget for day view.
   const DayView({
     Key? key,
@@ -175,6 +181,8 @@ class DayView<T extends Object?> extends StatefulWidget {
     this.onEventTap,
     this.onDateLongPress,
     this.minuteSlotSize = MinuteSlotSize.minutes60,
+    this.scrollPhysics,
+    this.pageViewPhysics,
   })  : assert(timeLineOffset >= 0,
             "timeLineOffset must be greater than or equal to 0"),
         assert(width == null || width > 0,
@@ -319,9 +327,11 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
               Expanded(
                 child: SingleChildScrollView(
                   controller: _scrollController,
+                  physics: widget.scrollPhysics,
                   child: SizedBox(
                     height: _height,
                     child: PageView.builder(
+                      physics: widget.pageViewPhysics,
                       itemCount: _totalDays,
                       controller: _pageController,
                       onPageChanged: _onPageChange,

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -30,8 +30,10 @@ extension DateTimeExtensions on DateTime {
   }
 
   /// Gets difference of days between [date] and calling object.
-  int getDayDifference(DateTime date) =>
-      withoutTime.difference(date.withoutTime).inDays.abs();
+  int getDayDifference(DateTime date) => DateTime.utc(year, month, day)
+      .difference(DateTime.utc(date.year, date.month, date.day))
+      .inDays
+      .abs();
 
   /// Gets difference of weeks between [date] and calling object.
   int getWeekDifference(DateTime date, {WeekDays start = WeekDays.monday}) =>

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import 'calendar_event_data.dart';
+import 'enumerations.dart';
 
 typedef CellBuilder<T extends Object?> = Widget Function(
   DateTime date,
@@ -20,6 +21,14 @@ typedef EventTileBuilder<T extends Object?> = Widget Function(
   DateTime startDuration,
   DateTime endDuration,
 );
+
+typedef DetectorBuilder<T extends Object?> = Widget Function({
+  required DateTime date,
+  required double height,
+  required double width,
+  required double heightPerMinute,
+  required MinuteSlotSize minuteSlotSize,
+});
 
 typedef WeekDayBuilder = Widget Function(
   int day,

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -67,6 +67,9 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
   /// Builder for week day title.
   final DateWidgetBuilder weekDayBuilder;
 
+  /// Builds custom PressDetector widget
+  final DetectorBuilder weekDetectorBuilder;
+
   /// Height of week title.
   final double weekTitleHeight;
 
@@ -121,6 +124,7 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
     required this.weekDays,
     required this.minuteSlotSize,
     required this.scrollConfiguration,
+    required this.weekDetectorBuilder,
   }) : super(key: key);
 
   @override
@@ -203,12 +207,11 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                                 width: weekTitleWidth,
                                 child: Stack(
                                   children: [
-                                    PressDetector(
+                                    weekDetectorBuilder(
                                       width: weekTitleWidth,
                                       height: height,
                                       heightPerMinute: heightPerMinute,
                                       date: dates[index],
-                                      onDateLongPress: onDateLongPress,
                                       minuteSlotSize: minuteSlotSize,
                                     ),
                                     EventGenerator<T>(

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -29,6 +29,12 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// Header builder for week page header.
   final WeekPageHeaderBuilder? weekPageHeaderBuilder;
 
+  /// Builds custom PressDetector widget
+  ///
+  /// If null, internal PressDetector will be used to handle onDateLongPress()
+  ///
+  final DetectorBuilder? weekDetectorBuilder;
+
   /// This function will generate dateString int the calendar header.
   /// Useful for I18n
   final StringProvider? headerStringBuilder;
@@ -185,6 +191,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
     this.showWeekends = true,
     this.startDay = WeekDays.monday,
     this.minuteSlotSize = MinuteSlotSize.minutes60,
+    this.weekDetectorBuilder,
     this.headerStringBuilder,
     this.timeLineStringBuilder,
     this.weekDayStringBuilder,
@@ -197,6 +204,10 @@ class WeekView<T extends Object?> extends StatefulWidget {
             "Time line width must be greater than 0."),
         assert(
             heightPerMinute > 0, "Height per minute must be greater than 0."),
+        assert(
+          weekDetectorBuilder == null || onDateLongPress == null,
+          "If you use [weekPressDetectorBuilder] do not provide [onDateLongPress]",
+        ),
         super(key: key);
 
   @override
@@ -227,6 +238,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
   late EventTileBuilder<T> _eventTileBuilder;
   late WeekPageHeaderBuilder _weekHeaderBuilder;
   late DateWidgetBuilder _weekDayBuilder;
+  late DetectorBuilder _weekDetectorBuilder;
 
   late double _weekTitleWidth;
   late int _totalDaysInWeek;
@@ -363,6 +375,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                                 weekTitleWidth: _weekTitleWidth,
                                 weekTitleHeight: widget.weekTitleHeight,
                                 weekDayBuilder: _weekDayBuilder,
+                                weekDetectorBuilder: _weekDetectorBuilder,
                                 liveTimeIndicatorSettings:
                                     _liveTimeIndicatorSettings,
                                 timeLineBuilder: _timeLineBuilder,
@@ -476,6 +489,8 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     _weekHeaderBuilder =
         widget.weekPageHeaderBuilder ?? _defaultWeekPageHeaderBuilder;
     _weekDayBuilder = widget.weekDayBuilder ?? _defaultWeekDayBuilder;
+    _weekDetectorBuilder =
+        widget.weekDetectorBuilder ?? _defaultPressDetectorBuilder;
   }
 
   /// Sets the current date of this month.
@@ -517,6 +532,49 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
 
     _totalWeeks =
         _minDate.getWeekDifference(_maxDate, start: widget.startDay) + 1;
+  }
+
+  /// Default press detector builder. This builder will be used if
+  /// [widget.weekDetectorBuilder] is null.
+  ///
+  Widget _defaultPressDetectorBuilder({
+    required DateTime date,
+    required double height,
+    required double width,
+    required double heightPerMinute,
+    required MinuteSlotSize minuteSlotSize,
+  }) {
+    final heightPerSlot = minuteSlotSize.minutes * heightPerMinute;
+    final slots = (Constants.hoursADay * 60) ~/ minuteSlotSize.minutes;
+
+    return Container(
+      height: height,
+      width: width,
+      child: Stack(
+        children: [
+          for (int i = 0; i < slots; i++)
+            Positioned(
+              top: heightPerSlot * i,
+              left: 0,
+              right: 0,
+              bottom: height - (heightPerSlot * (i + 1)),
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onLongPress: () => widget.onDateLongPress?.call(
+                  DateTime(
+                    date.year,
+                    date.month,
+                    date.day,
+                    0,
+                    minuteSlotSize.minutes * i,
+                  ),
+                ),
+                child: SizedBox(width: width, height: heightPerSlot),
+              ),
+            ),
+        ],
+      ),
+    );
   }
 
   /// Default builder for week line.


### PR DESCRIPTION
The pull request adds:
- Support for custom physics to enable disabling PageVIew and CustomScrollView.
- Custom builders for a detector that will be below tiles and enables custom behavior. On similar principle works already onDateLongPress; these builders will allow us to do this manually. This pull request keeps the default behavior.
- Fix for #97 and #80 by @francescovgg that I need, and he seems inactive.

Example behavior that I can achieve thanks to this pull request.

![showcase](https://user-images.githubusercontent.com/68862752/191793573-cc6364a2-9742-4b75-aa2d-6f05184ad7d3.gif)
