### PR TITLE
Revert "Change starting time of day view"

### DIFF
--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -35,19 +35,15 @@ class LiveTimeIndicator extends StatefulWidget {
   /// Defines height occupied by one minute.
   final double heightPerMinute;
 
-  /// Define start time of day.
-  final int startTime;
-
   /// Widget to display tile line according to current time.
-  const LiveTimeIndicator({
-    Key? key,
-    required this.width,
-    required this.height,
-    required this.timeLineWidth,
-    required this.liveTimeIndicatorSettings,
-    required this.heightPerMinute,
-    this.startTime = 1,
-  }) : super(key: key);
+  const LiveTimeIndicator(
+      {Key? key,
+      required this.width,
+      required this.height,
+      required this.timeLineWidth,
+      required this.liveTimeIndicatorSettings,
+      required this.heightPerMinute})
+      : super(key: key);
 
   @override
   _LiveTimeIndicatorState createState() => _LiveTimeIndicatorState();
@@ -60,8 +56,8 @@ class _LiveTimeIndicatorState extends State<LiveTimeIndicator> {
   @override
   void initState() {
     super.initState();
-    _currentDate = DateTime.now().subtract(
-        Duration(hours: (widget.startTime - 1) % Constants.hoursADay));
+
+    _currentDate = DateTime.now();
     _timer = Timer(Duration(seconds: 1), setTimer);
   }
 
@@ -77,8 +73,7 @@ class _LiveTimeIndicatorState extends State<LiveTimeIndicator> {
   void setTimer() {
     if (mounted) {
       setState(() {
-        _currentDate = DateTime.now().subtract(
-            Duration(hours: (widget.startTime - 1) % Constants.hoursADay));
+        _currentDate = DateTime.now();
         _timer = Timer(Duration(seconds: 1), setTimer);
       });
     }
@@ -120,14 +115,14 @@ class TimeLine extends StatelessWidget {
   static DateTime get _date => DateTime.now();
 
   /// Time line to display time at left side of day or week view.
-  const TimeLine({
-    Key? key,
-    required this.timeLineWidth,
-    required this.hourHeight,
-    required this.height,
-    required this.timeLineOffset,
-    required this.timeLineBuilder,
-  }) : super(key: key);
+  const TimeLine(
+      {Key? key,
+      required this.timeLineWidth,
+      required this.hourHeight,
+      required this.height,
+      required this.timeLineOffset,
+      required this.timeLineBuilder})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -194,9 +189,6 @@ class EventGenerator<T extends Object?> extends StatelessWidget {
 
   final EventScrollConfiguration scrollNotifier;
 
-  /// Define start time of day.
-  final int startTime;
-
   /// A widget that display event tiles in day/week view.
   const EventGenerator({
     Key? key,
@@ -209,7 +201,6 @@ class EventGenerator<T extends Object?> extends StatelessWidget {
     required this.date,
     required this.onTileTap,
     required this.scrollNotifier,
-    this.startTime = 1,
   }) : super(key: key);
 
   /// Arrange events and returns list of [Widget] that displays event
@@ -221,7 +212,6 @@ class EventGenerator<T extends Object?> extends StatelessWidget {
       height: height,
       width: width,
       heightPerMinute: heightPerMinute,
-      dayStartTime: startTime,
     );
 
     return List.generate(events.length, (index) {
@@ -309,9 +299,6 @@ class PressDetector extends StatelessWidget {
   /// where events are not available.
   final MinuteSlotSize minuteSlotSize;
 
-  ///Define start time of day
-  final int startTime;
-
   /// A widget that display event tiles in day/week view.
   const PressDetector({
     Key? key,
@@ -321,7 +308,6 @@ class PressDetector extends StatelessWidget {
     required this.date,
     required this.onDateLongPress,
     required this.minuteSlotSize,
-    this.startTime = 1,
   }) : super(key: key);
 
   @override
@@ -348,11 +334,7 @@ class PressDetector extends StatelessWidget {
                     date.month,
                     date.day,
                     0,
-                    minuteSlotSize.minutes *
-                        ((i +
-                                (startTime - 1) *
-                                    (slots ~/ Constants.hoursADay)) %
-                            slots),
+                    minuteSlotSize.minutes * i,
                   ),
                 ),
                 child: SizedBox(width: width, height: heightPerSlot),

--- a/lib/src/components/day_view_components.dart
+++ b/lib/src/components/day_view_components.dart
@@ -153,27 +153,19 @@ class DefaultTimeLineMark extends StatelessWidget {
   /// Text style for time string.
   final TextStyle? markingStyle;
 
-  /// Define start time of day.
-  final int startTime;
-
   /// Time marker for timeline used in week and day view.
   const DefaultTimeLineMark({
     Key? key,
     required this.date,
     this.markingStyle,
     this.timeStringBuilder,
-    this.startTime = 1,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final getAmPm =
-        ((date.hour + (startTime - 1)) % Constants.hoursADay) ~/ 12 == 0
-            ? 'am'
-            : 'pm';
     final timeString = (timeStringBuilder != null)
         ? timeStringBuilder!(date)
-        : "${((date.hour - 1 + (startTime - 1)) % 12) + 1} $getAmPm";
+        : "${((date.hour - 1) % 12) + 1} ${date.hour ~/ 12 == 0 ? "am" : "pm"}";
     return Transform.translate(
       offset: Offset(0, -7.5),
       child: Padding(

--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -77,9 +77,6 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
   /// Notifies if there is any event that needs to be visible instantly.
   final EventScrollConfiguration scrollNotifier;
 
-  /// Define start time of day view
-  final int startTime;
-
   /// Defines a single day page.
   const InternalDayViewPage({
     Key? key,
@@ -103,7 +100,6 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
     required this.onDateLongPress,
     required this.minuteSlotSize,
     required this.scrollNotifier,
-    this.startTime = 1,
   }) : super(key: key);
 
   @override
@@ -131,7 +127,6 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
             date: date,
             onDateLongPress: onDateLongPress,
             minuteSlotSize: minuteSlotSize,
-            startTime: startTime,
           ),
           Align(
             alignment: Alignment.centerRight,
@@ -148,7 +143,6 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
                   timeLineWidth -
                   hourIndicatorSettings.offset -
                   verticalLineOffset,
-              startTime: startTime,
             ),
           ),
           TimeLine(
@@ -167,7 +161,6 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
                 height: height,
                 heightPerMinute: heightPerMinute,
                 timeLineWidth: timeLineWidth,
-                startTime: startTime,
               ),
             ),
         ],

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -149,9 +149,6 @@ class DayView<T extends Object?> extends StatefulWidget {
   /// Style for DayView header.
   final HeaderStyle headerStyle;
 
-  /// Define start time of day view.
-  final int startTime;
-
   /// Main widget for day view.
   const DayView({
     Key? key,
@@ -182,7 +179,6 @@ class DayView<T extends Object?> extends StatefulWidget {
     this.onEventTap,
     this.onDateLongPress,
     this.minuteSlotSize = MinuteSlotSize.minutes60,
-    this.startTime = 1,
     this.headerStyle = const HeaderStyle(),
   })  : assert(timeLineOffset >= 0,
             "timeLineOffset must be greater than or equal to 0"),
@@ -339,35 +335,34 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
                             _minDate.day + index);
 
                         return ValueListenableBuilder(
-                          valueListenable: _scrollConfiguration,
-                          builder: (_, __, ___) => InternalDayViewPage<T>(
-                            key: ValueKey(
-                                _hourHeight.toString() + date.toString()),
-                            width: _width,
-                            liveTimeIndicatorSettings:
-                                _liveTimeIndicatorSettings,
-                            timeLineBuilder: _timeLineBuilder,
-                            eventTileBuilder: _eventTileBuilder,
-                            heightPerMinute: widget.heightPerMinute,
-                            hourIndicatorSettings: _hourIndicatorSettings,
-                            date: date,
-                            onTileTap: widget.onEventTap,
-                            onDateLongPress: widget.onDateLongPress,
-                            showLiveLine: widget.showLiveTimeLineInAllDays ||
-                                date.compareWithoutTime(DateTime.now()),
-                            timeLineOffset: widget.timeLineOffset,
-                            timeLineWidth: _timeLineWidth,
-                            verticalLineOffset: widget.verticalLineOffset,
-                            showVerticalLine: widget.showVerticalLine,
-                            height: _height,
-                            controller: controller,
-                            hourHeight: _hourHeight,
-                            eventArranger: _eventArranger,
-                            minuteSlotSize: widget.minuteSlotSize,
-                            scrollNotifier: _scrollConfiguration,
-                            startTime: widget.startTime,
-                          ),
-                        );
+                            valueListenable: _scrollConfiguration,
+                            builder: (_, __, ___) => InternalDayViewPage<T>(
+                                  key: ValueKey(
+                                      _hourHeight.toString() + date.toString()),
+                                  width: _width,
+                                  liveTimeIndicatorSettings:
+                                      _liveTimeIndicatorSettings,
+                                  timeLineBuilder: _timeLineBuilder,
+                                  eventTileBuilder: _eventTileBuilder,
+                                  heightPerMinute: widget.heightPerMinute,
+                                  hourIndicatorSettings: _hourIndicatorSettings,
+                                  date: date,
+                                  onTileTap: widget.onEventTap,
+                                  onDateLongPress: widget.onDateLongPress,
+                                  showLiveLine: widget
+                                          .showLiveTimeLineInAllDays ||
+                                      date.compareWithoutTime(DateTime.now()),
+                                  timeLineOffset: widget.timeLineOffset,
+                                  timeLineWidth: _timeLineWidth,
+                                  verticalLineOffset: widget.verticalLineOffset,
+                                  showVerticalLine: widget.showVerticalLine,
+                                  height: _height,
+                                  controller: controller,
+                                  hourHeight: _hourHeight,
+                                  eventArranger: _eventArranger,
+                                  minuteSlotSize: widget.minuteSlotSize,
+                                  scrollNotifier: _scrollConfiguration,
+                                ));
                       },
                     ),
                   ),
@@ -474,10 +469,7 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   /// [widget.eventTileBuilder] is null
   ///
   Widget _defaultTimeLineBuilder(date) => DefaultTimeLineMark(
-        date: date,
-        timeStringBuilder: widget.timeStringBuilder,
-        startTime: widget.startTime,
-      );
+      date: date, timeStringBuilder: widget.timeStringBuilder);
 
   /// Default timeline builder. This builder will be used if
   /// [widget.eventTileBuilder] is null

--- a/lib/src/event_arrangers/event_arrangers.dart
+++ b/lib/src/event_arrangers/event_arrangers.dart
@@ -5,7 +5,6 @@
 import 'dart:math' as math;
 
 import '../calendar_event_data.dart';
-import '../constants.dart';
 import '../extensions.dart';
 
 part 'merge_event_arranger.dart';
@@ -29,7 +28,6 @@ abstract class EventArranger<T extends Object?> {
     required double height,
     required double width,
     required double heightPerMinute,
-    required int dayStartTime,
   });
 }
 

--- a/lib/src/event_arrangers/merge_event_arranger.dart
+++ b/lib/src/event_arrangers/merge_event_arranger.dart
@@ -17,7 +17,6 @@ class MergeEventArranger<T extends Object?> extends EventArranger<T> {
     required double height,
     required double width,
     required double heightPerMinute,
-    required int dayStartTime,
   }) {
     final arrangedEvents = <OrganizedCalendarEventData<T>>[];
 
@@ -32,12 +31,8 @@ class MergeEventArranger<T extends Object?> extends EventArranger<T> {
           "This error occurs when you does not provide startDate or endDate in "
           "CalendarEventDate or provided endDate occurs before startDate.");
 
-      final eventStart = startTime
-          .subtract(Duration(hours: (dayStartTime - 1) % Constants.hoursADay))
-          .getTotalMinutes;
-      final eventEnd = endTime
-          .subtract(Duration(hours: (dayStartTime - 1) % Constants.hoursADay))
-          .getTotalMinutes;
+      final eventStart = startTime.getTotalMinutes;
+      final eventEnd = endTime.getTotalMinutes;
 
       final arrangeEventLen = arrangedEvents.length;
 

--- a/lib/src/event_arrangers/side_event_arranger.dart
+++ b/lib/src/event_arrangers/side_event_arranger.dart
@@ -15,7 +15,6 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     required double height,
     required double width,
     required double heightPerMinute,
-    required int dayStartTime,
   }) {
     final durations = _getEventsDuration(events);
     final tempEvents = [...events]..sort((e1, e2) =>
@@ -66,19 +65,10 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
         if (table[i][j] != null && (event == null || table[i][j] != event)) {
           event = table[i][j];
 
-          final top = (event!.startTime
-                      ?.subtract(Duration(
-                          hours: (dayStartTime - 1) % Constants.hoursADay))
-                      .getTotalMinutes ??
-                  0) *
-              heightPerMinute;
+          final top =
+              (event!.startTime?.getTotalMinutes ?? 0) * heightPerMinute;
           final bottom = height -
-              ((event.endTime
-                          ?.subtract(Duration(
-                              hours: (dayStartTime - 1) % Constants.hoursADay))
-                          .getTotalMinutes ??
-                      0) *
-                  heightPerMinute);
+              ((event.endTime?.getTotalMinutes ?? 0) * heightPerMinute);
           final left = widthPerCol * i;
           final right = width - (left + widthPerCol);
 


### PR DESCRIPTION
Reverts SimformSolutionsPvtLtd/flutter_calendar_view#112

Need to discuss more scenarios, For example we have `DayView` set with startTime of 4, Then it will start the DayView page at 4 AM and move 1-3 AM at the bottom of the page. Now,

- How will the events that is scheduled for 2 to 4 AM will be displayed? Should the event be displayed in previous day page or we will not display the event at all.
- Should we display the 1-3 AM time slots or will it be completely removed?
- Should we only provide startTime or developer can define the range. As example, developer can define Time from 10AM to 6 PM So, `DavView` will only display events that occurs between 10 AM to 6 PM.