### PR TITLE
fix: day view width

### DIFF
--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -449,6 +449,10 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
 
   /// Updates data related to size of this view.
   void _updateViewDimensions() {
+    _width = widget.width;
+
+    _timeLineWidth = widget.timeLineWidth;
+
     _liveTimeIndicatorSettings = widget.liveTimeIndicatorSettings ??
         HourIndicatorSettings(
           color: Constants.defaultLiveTimeIndicatorColor,

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -234,9 +234,9 @@ class DayView<T extends Object?> extends StatefulWidget {
 }
 
 class DayViewState<T extends Object?> extends State<DayView<T>> {
-  late double _width;
+  double? _width;
   late double _height;
-  late double _timeLineWidth;
+  double? _timeLineWidth;
   late double _hourHeight;
   late DateTime _currentDate;
   late DateTime _maxDate;
@@ -356,67 +356,73 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   Widget build(BuildContext context) {
     return SafeAreaWrapper(
       option: widget.safeAreaOption,
-      child: SizedBox(
-        width: _width,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: widget.backgroundColor,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _dayTitleBuilder(_currentDate),
-              Expanded(
-                child: SizedBox(
-                  height: _height,
-                  child: PageView.builder(
-                    physics: widget.pageViewPhysics,
-                    itemCount: _totalDays,
-                    controller: _pageController,
-                    onPageChanged: _onPageChange,
-                    itemBuilder: (_, index) {
-                      final date = DateTime(
-                          _minDate.year, _minDate.month, _minDate.day + index);
-                      return ValueListenableBuilder(
-                        valueListenable: _scrollConfiguration,
-                        builder: (_, __, ___) => InternalDayViewPage<T>(
-                          key: ValueKey(
-                              _hourHeight.toString() + date.toString()),
-                          width: _width,
-                          liveTimeIndicatorSettings: _liveTimeIndicatorSettings,
-                          timeLineBuilder: _timeLineBuilder,
-                          dayDetectorBuilder: _dayDetectorBuilder,
-                          eventTileBuilder: _eventTileBuilder,
-                          heightPerMinute: widget.heightPerMinute,
-                          hourIndicatorSettings: _hourIndicatorSettings,
-                          date: date,
-                          onTileTap: widget.onEventTap,
-                          onDateLongPress: widget.onDateLongPress,
-                          onDateTap: widget.onDateTap,
-                          showLiveLine: widget.showLiveTimeLineInAllDays ||
-                              date.compareWithoutTime(DateTime.now()),
-                          timeLineOffset: widget.timeLineOffset,
-                          timeLineWidth: _timeLineWidth,
-                          verticalLineOffset: widget.verticalLineOffset,
-                          showVerticalLine: widget.showVerticalLine,
-                          height: _height,
-                          controller: controller,
-                          hourHeight: _hourHeight,
-                          eventArranger: _eventArranger,
-                          minuteSlotSize: widget.minuteSlotSize,
-                          scrollNotifier: _scrollConfiguration,
-                          fullDayEventBuilder: _fullDayEventBuilder,
-                          scrollController: _scrollController,
-                        ),
-                      );
-                    },
-                  ),
-                ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final maxWidth = constraints.maxWidth;
+          return SizedBox(
+            width: _width ?? maxWidth,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: widget.backgroundColor,
               ),
-            ],
-          ),
-        ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _dayTitleBuilder(_currentDate),
+                  Expanded(
+                    child: SizedBox(
+                      height: _height,
+                      child: PageView.builder(
+                        physics: widget.pageViewPhysics,
+                        itemCount: _totalDays,
+                        controller: _pageController,
+                        onPageChanged: _onPageChange,
+                        itemBuilder: (_, index) {
+                          final date = DateTime(_minDate.year, _minDate.month,
+                              _minDate.day + index);
+                          return ValueListenableBuilder(
+                            valueListenable: _scrollConfiguration,
+                            builder: (_, __, ___) => InternalDayViewPage<T>(
+                              key: ValueKey(
+                                  _hourHeight.toString() + date.toString()),
+                              width: _width ?? maxWidth,
+                              liveTimeIndicatorSettings:
+                                  _liveTimeIndicatorSettings,
+                              timeLineBuilder: _timeLineBuilder,
+                              dayDetectorBuilder: _dayDetectorBuilder,
+                              eventTileBuilder: _eventTileBuilder,
+                              heightPerMinute: widget.heightPerMinute,
+                              hourIndicatorSettings: _hourIndicatorSettings,
+                              date: date,
+                              onTileTap: widget.onEventTap,
+                              onDateLongPress: widget.onDateLongPress,
+                              onDateTap: widget.onDateTap,
+                              showLiveLine: widget.showLiveTimeLineInAllDays ||
+                                  date.compareWithoutTime(DateTime.now()),
+                              timeLineOffset: widget.timeLineOffset,
+                              timeLineWidth: _timeLineWidth ?? maxWidth * 0.13,
+                              verticalLineOffset: widget.verticalLineOffset,
+                              showVerticalLine: widget.showVerticalLine,
+                              height: _height,
+                              controller: controller,
+                              hourHeight: _hourHeight,
+                              eventArranger: _eventArranger,
+                              minuteSlotSize: widget.minuteSlotSize,
+                              scrollNotifier: _scrollConfiguration,
+                              fullDayEventBuilder: _fullDayEventBuilder,
+                              scrollController: _scrollController,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
       ),
     );
   }
@@ -443,10 +449,6 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
 
   /// Updates data related to size of this view.
   void _updateViewDimensions() {
-    _width = widget.width ?? MediaQuery.of(context).size.width;
-
-    _timeLineWidth = widget.timeLineWidth ?? _width * 0.13;
-
     _liveTimeIndicatorSettings = widget.liveTimeIndicatorSettings ??
         HourIndicatorSettings(
           color: Constants.defaultLiveTimeIndicatorColor,


### PR DESCRIPTION
# Description

## Existing Behavior

When creating a `DayView()` and not specifying width, the width defaults to the width of the screen.  This causes any overlapping events to be given too small of a width.

## Updated Behavior

Instead of defaulting width to the size of the screen, it now defaults to incoming width constraints given to the day view.

## Checklist

*The contributors guide requires tests for PR's, however there are currently no tests setup for this package that I'm seeing.  Did I miss something?

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?


### Migration instructions

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Currently no open issue for this bug.