### PR TITLE
fix: day view not showing first day of ranged event

### DIFF
--- a/lib/src/event_controller.dart
+++ b/lib/src/event_controller.dart
@@ -120,11 +120,12 @@ class EventController<T extends Object?> extends ChangeNotifier {
       events.addAll(_calendarData.events[date]!);
     }
 
+    final lastMomentOfDay = DateTime(date.year, date.month, date.day + 1);
     for (final rangingEvent in _calendarData.rangingEventList) {
       if (date == rangingEvent.date ||
           date == rangingEvent.endDate ||
           (date.isBefore(rangingEvent.endDate) &&
-              date.isAfter(rangingEvent.date))) {
+              lastMomentOfDay.isAfter(rangingEvent.date))) {
         events.add(rangingEvent);
       }
     }


### PR DESCRIPTION
# Description
On the day view calendar, when showing a multi-day event, the first day of the event is not shown.  (All the other days are shown).

### To test

- Create a day view calendar
- Create a multi day event
- Ensure that the first day of the event is shown

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

No related issues.