### PR TITLE
fix: :bug: DisplayBorder=false should hide border of WeekDayTile

### DIFF
--- a/lib/src/components/month_view_components.dart
+++ b/lib/src/components/month_view_components.dart
@@ -257,10 +257,12 @@ class WeekDayTile extends StatelessWidget {
       padding: EdgeInsets.symmetric(vertical: 10.0),
       decoration: BoxDecoration(
         color: backgroundColor,
-        border: Border.all(
-          color: Constants.defaultBorderColor,
-          width: displayBorder ? 0.5 : 0,
-        ),
+        border: displayBorder
+            ? Border.all(
+                color: Constants.defaultBorderColor,
+                width: 0.5,
+              )
+            : null,
       ),
       child: Text(
         weekDayStringBuilder?.call(dayIndex) ?? Constants.weekTitles[dayIndex],


### PR DESCRIPTION
# Description
The parameter "displayBorder" already existed for WeekDayTile, but setting it to False did not hide the weekday tile border. Now, setting displayBorder to False will cause the border to be null, not just 0 width.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #191 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org