### PR TITLE
fix: some DateTimeExtensions methods are not working properly for Daylight Saving Time

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -44,7 +44,8 @@ extension DateTimeExtensions on DateTime {
               7)
           .ceil();
 
-  /// Returns The List of date of Current Week
+  /// Returns The List of date of Current Week, all of the dates will be without
+  /// time.
   /// Day will start from Monday to Sunday.
   ///
   /// ex: if Current Date instance is 8th and day is wednesday then weekDates
@@ -61,26 +62,26 @@ extension DateTimeExtensions on DateTime {
     //    difference = (weekdays - (start.index + 1))%7
     //
     final startDay =
-        withoutTime.subtract(Duration(days: (weekday - start.index - 1) % 7));
+        DateTime(year, month, day - (weekday - start.index - 1) % 7);
 
     return [
       startDay,
-      startDay.add(Duration(days: 1)),
-      startDay.add(Duration(days: 2)),
-      startDay.add(Duration(days: 3)),
-      startDay.add(Duration(days: 4)),
-      startDay.add(Duration(days: 5)),
-      startDay.add(Duration(days: 6)),
+      DateTime(startDay.year, startDay.month, startDay.day + 1),
+      DateTime(startDay.year, startDay.month, startDay.day + 2),
+      DateTime(startDay.year, startDay.month, startDay.day + 3),
+      DateTime(startDay.year, startDay.month, startDay.day + 4),
+      DateTime(startDay.year, startDay.month, startDay.day + 5),
+      DateTime(startDay.year, startDay.month, startDay.day + 6),
     ];
   }
 
   /// Returns the first date of week containing the current date
   DateTime firstDayOfWeek({WeekDays start = WeekDays.monday}) =>
-      withoutTime.subtract(Duration(days: (weekday - start.index - 1) % 7));
+      DateTime(year, month, day - ((weekday - start.index - 1) % 7));
 
   /// Returns the last date of week containing the current date
   DateTime lastDayOfWeek({WeekDays start = WeekDays.monday}) =>
-      withoutTime.add(Duration(days: 6 - (weekday - start.index - 1) % 7));
+      DateTime(year, month, day + (6 - (weekday - start.index - 1) % 7));
 
   /// Returns list of all dates of [month].
   /// All the dates are week based that means it will return array of size 42
@@ -127,7 +128,10 @@ extension DateTimeExtensions on DateTime {
 
   bool get isDayStart => hour % 24 == 0 && minute % 60 == 0;
 
-  DateTime get dateYMD => DateTime(year, day, hour);
+  @Deprecated(
+      "This extension is not being used in this package and will be removed "
+      "in next major release. Please use withoutTime instead.")
+  DateTime get dateYMD => DateTime(year, month, day);
 }
 
 extension ColorExtension on Color {

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -396,8 +396,8 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                     controller: _pageController,
                     onPageChanged: _onPageChange,
                     itemBuilder: (_, index) {
-                      final dates = _minDate
-                          .add(Duration(days: index * DateTime.daysPerWeek))
+                      final dates = DateTime(_minDate.year, _minDate.month,
+                              _minDate.day + (index * DateTime.daysPerWeek))
                           .datesOfWeek(start: widget.startDay);
 
                       return ValueListenableBuilder(

--- a/lib/test/extensions_test.dart
+++ b/lib/test/extensions_test.dart
@@ -1,0 +1,182 @@
+import 'package:test/test.dart';
+
+import '../calendar_view.dart';
+
+void main() {
+  group('DateTimeExtensions', () {
+    test('datesOfWeek_simple', () {
+      testDatesOfWeekForAllWeekDayStarts(DateTime(2023, 02, 25));
+    });
+    test('datesOfWeek_DaylightSavingTime-2023-03-26', () {
+      // Just to be sure, testing for dates adjecent to daylinght saving time
+      testDatesOfWeekForAllWeekDayStarts(DateTime(2023, 03, 25));
+      testDatesOfWeekForAllWeekDayStarts(DateTime(2023, 03, 26));
+      testDatesOfWeekForAllWeekDayStarts(DateTime(2023, 03, 27));
+    });
+    test('datesOfWeek_DaylightSavingTime-2023-10-29', () {
+      // Just to be sure, testing for dates adjecent to daylinght saving time
+      testDatesOfWeekForAllWeekDayStarts(DateTime(2023, 10, 28));
+      testDatesOfWeekForAllWeekDayStarts(DateTime(2023, 10, 29));
+      testDatesOfWeekForAllWeekDayStarts(DateTime(2023, 10, 30));
+    });
+    test('firstDayOfWeek_simple', () {
+      testAllFirstDayOfTheWeek(DateTime(2023, 02, 25));
+    });
+    test('firstDayOfWeek_DaylightSavingTime-2023-03-26', () {
+      // Just to be sure, testing for dates adjecent to daylinght saving time
+      testAllFirstDayOfTheWeek(DateTime(2023, 03, 25));
+      testAllFirstDayOfTheWeek(DateTime(2023, 03, 26));
+      testAllFirstDayOfTheWeek(DateTime(2023, 03, 27));
+    });
+    test('firstDayOfWeek_DaylightSavingTime-2023-10-29', () {
+      // Just to be sure, testing for dates adjecent to daylinght saving time
+      testAllFirstDayOfTheWeek(DateTime(2023, 10, 28));
+      testAllFirstDayOfTheWeek(DateTime(2023, 10, 29));
+      testAllFirstDayOfTheWeek(DateTime(2023, 10, 30));
+    });
+    test('lastDayOfWeek_simple', () {
+      testAllLastDayOfTheWeek(DateTime(2023, 02, 25));
+    });
+    test('lastDayOfWeek_DaylightSavingTime-2023-03-26', () {
+      // Just to be sure, testing for dates adjecent to daylinght saving time
+      testAllLastDayOfTheWeek(DateTime(2023, 03, 25));
+      testAllLastDayOfTheWeek(DateTime(2023, 03, 26));
+      testAllLastDayOfTheWeek(DateTime(2023, 03, 27));
+    });
+    test('lastDayOfWeek_DaylightSavingTime-2023-10-29', () {
+      // Just to be sure, testing for dates adjecent to daylinght saving time
+      testAllLastDayOfTheWeek(DateTime(2023, 10, 28));
+      testAllLastDayOfTheWeek(DateTime(2023, 10, 29));
+      testAllLastDayOfTheWeek(DateTime(2023, 10, 30));
+    });
+  });
+}
+
+/// Does datesOfWeek tests for this date with all 7 [WeekDays] as starts.
+void testDatesOfWeekForAllWeekDayStarts(DateTime date) {
+  for (final start in WeekDays.values) {
+    testDatesOfWeek(
+      getWeekStartDay(date, start),
+      date.datesOfWeek(start: start),
+    );
+  }
+}
+
+void testDatesOfWeek(DateTime firstDay, List<DateTime> result) {
+  expect(result.length, 7, reason: "There must be 7 dates in a week!");
+
+  expect(result[0], DateTime(firstDay.year, firstDay.month, firstDay.day));
+  expect(result[1], DateTime(firstDay.year, firstDay.month, firstDay.day + 1));
+  expect(result[2], DateTime(firstDay.year, firstDay.month, firstDay.day + 2));
+  expect(result[3], DateTime(firstDay.year, firstDay.month, firstDay.day + 3));
+  expect(result[4], DateTime(firstDay.year, firstDay.month, firstDay.day + 4));
+  expect(result[5], DateTime(firstDay.year, firstDay.month, firstDay.day + 5));
+  expect(result[6], DateTime(firstDay.year, firstDay.month, firstDay.day + 6));
+}
+
+/// Does exactly 7x7 = 49 tests, testing this date and 6 next consecutive dates
+/// as referent first days of the week, and for each referent first day of the
+/// week does tests that this date and its 7 consecutive days are pointing it as
+/// a first day of the week.
+void testAllFirstDayOfTheWeek(DateTime date) {
+  for (var i = 0; i < 7; i++) {
+    final testDate = DateTime(
+      date.year,
+      date.month,
+      date.day + i,
+    );
+
+    testFirstDayOfTheWeekForAllWeekDays(testDate);
+  }
+}
+
+void testFirstDayOfTheWeekForAllWeekDays(DateTime firstDayOfTheWeek) {
+  final weekDays = getWeekDays(firstDayOfTheWeek);
+  for (var i = 0; i < 7; i++) {
+    final date = DateTime(
+      firstDayOfTheWeek.year,
+      firstDayOfTheWeek.month,
+      firstDayOfTheWeek.day + i,
+    );
+
+    expect(firstDayOfTheWeek, date.firstDayOfWeek(start: weekDays));
+  }
+}
+
+/// Does exactly 7x7 = 49 tests, testing this date and 6 consecutive dates as
+/// referent last days of the week, and for each referent last day of the week
+/// does tests that this date and its previous days are pointing it as a last
+/// day of the week.
+void testAllLastDayOfTheWeek(DateTime date) {
+  for (var i = 0; i < 7; i++) {
+    final testDate = DateTime(
+      date.year,
+      date.month,
+      date.day + i,
+    );
+
+    testLastDayOfTheWeekForAllWeekDays(testDate);
+  }
+}
+
+void testLastDayOfTheWeekForAllWeekDays(DateTime lastDayOfTheWeek) {
+  final weekDays = nextWeekDays(getWeekDays(lastDayOfTheWeek));
+  for (var i = 0; i < 7; i++) {
+    final date = DateTime(
+      lastDayOfTheWeek.year,
+      lastDayOfTheWeek.month,
+      lastDayOfTheWeek.day - i,
+    );
+
+    expect(lastDayOfTheWeek, date.lastDayOfWeek(start: weekDays));
+  }
+}
+
+DateTime getWeekStartDay(DateTime date, WeekDays start) {
+  final weekStartDay = DateTime(
+      date.year, date.month, date.day - (date.weekday - start.index - 1) % 7);
+  return DateTime(weekStartDay.year, weekStartDay.month, weekStartDay.day);
+}
+
+WeekDays getWeekDays(DateTime date) {
+  switch (date.weekday) {
+    case 1:
+      return WeekDays.monday;
+    case 2:
+      return WeekDays.tuesday;
+    case 3:
+      return WeekDays.wednesday;
+    case 4:
+      return WeekDays.thursday;
+    case 5:
+      return WeekDays.friday;
+    case 6:
+      return WeekDays.saturday;
+    case 7:
+      return WeekDays.sunday;
+    default:
+      throw Exception("""
+        Date $date has unrecognisable weekday expencted [1-7], 
+        but ${date.weekday} was provided.
+          """);
+  }
+}
+
+WeekDays nextWeekDays(WeekDays current) {
+  switch (current) {
+    case WeekDays.monday:
+      return WeekDays.tuesday;
+    case WeekDays.tuesday:
+      return WeekDays.wednesday;
+    case WeekDays.wednesday:
+      return WeekDays.thursday;
+    case WeekDays.thursday:
+      return WeekDays.friday;
+    case WeekDays.friday:
+      return WeekDays.saturday;
+    case WeekDays.saturday:
+      return WeekDays.sunday;
+    case WeekDays.sunday:
+      return WeekDays.monday;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,5 +15,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  test: ^1.22.0
 
 flutter:


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
#### Calendar's WeekView is not showing some events in the week of Daylight Saving Time.
The issue is caused by the fact that `DateTimeExtensions` methods use `Duration` to move between adjacent days, and that approach is bugged in the events of Daylight Saving Time (Sun, Mar 26, 2023 2:00 AM and Sun, Oct 29, 2023 3:00 AM).
##### To test the incorrect behavior (view Issue #197):
- Create a week view calendar
- Set week startDay on **sunday**
- Create events that span on days: 2023-03-27 - 2023-04-01

##### This PR contains changes:
- Fixed `DateTimeExtensions` methods to use `DateTime` constructor instead of adding `Duration`
- Added unit testing to project
  - Added tests in new test/extensions_test.dart testing file that verifies that the issue is fixed.
- Fixing and deprecating `dateYMD` method in `DateTimeExtensions`
  - This method was unused, bugged and was supposed to do the same thing as `withoutTime` method.
- Fixing one place in week_view.dart file which uses `Duration` to move between days.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Issue #197 
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org