### PR TITLE
fix: 🐛Unwanted space at top of dayView while using sliver #225.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   Issue [#237 - DayView & MonthView layout issue in landscape mode](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/237)
 - Added Feature
   [#57 - Change default start hour in DayView](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/57)
+- Fixed 
+  Issue [#225 - Unwanted space at top in DayView while using sliver](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/225)
+
 
 # [1.0.3 - 3 Apr 2023](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.0.3)
 

--- a/lib/src/components/day_view_components.dart
+++ b/lib/src/components/day_view_components.dart
@@ -140,6 +140,7 @@ class DayPageHeader extends CalendarPageHeader {
               dateStringBuilder ?? DayPageHeader._dayStringBuilder,
           headerStyle: headerStyle,
         );
+
   static String _dayStringBuilder(DateTime date, {DateTime? secondaryDate}) =>
       "${date.day} - ${date.month} - ${date.year}";
 }
@@ -227,7 +228,7 @@ class FullDayEventView<T> extends StatelessWidget {
       constraints: boxConstraints,
       child: ListView.builder(
         itemCount: events.length,
-        padding: padding,
+        padding: padding ?? EdgeInsets.zero,
         shrinkWrap: true,
         itemBuilder: (context, index) => InkWell(
           onTap: () => onEventTap?.call(events[index], date),

--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -133,12 +133,15 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final fullDayEventList = controller.getFullDayEvent(date);
     return Container(
       height: height,
       width: width,
       child: Column(
         children: [
-          fullDayEventBuilder(controller.getFullDayEvent(date), date),
+          fullDayEventList.isEmpty
+              ? SizedBox.shrink()
+              : fullDayEventBuilder(fullDayEventList, date),
           Expanded(
             child: SingleChildScrollView(
               controller: scrollController,

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -109,7 +109,7 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
   final EventScrollConfiguration scrollConfiguration;
 
   /// Display full day events.
-  final FullDayEventBuilder<T>? fullDayEventBuilder;
+  final FullDayEventBuilder<T> fullDayEventBuilder;
 
   /// A single page for week view.
   const InternalWeekViewPage({
@@ -141,7 +141,7 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
     required this.weekDays,
     required this.minuteSlotSize,
     required this.scrollConfiguration,
-    this.fullDayEventBuilder,
+    required this.fullDayEventBuilder,
     required this.weekDetectorBuilder,
   }) : super(key: key);
 
@@ -189,13 +189,19 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                 SizedBox(width: timeLineWidth + hourIndicatorSettings.offset),
                 ...List.generate(
                   filteredDates.length,
-                  (index) => SizedBox(
-                    width: weekTitleWidth,
-                    child: fullDayEventBuilder?.call(
-                      controller.getFullDayEvent(filteredDates[index]),
-                      dates[index],
-                    ),
-                  ),
+                  (index) {
+                    final fullDayEventList =
+                        controller.getFullDayEvent(filteredDates[index]);
+                    return fullDayEventList.isEmpty
+                        ? SizedBox.shrink()
+                        : SizedBox(
+                            width: weekTitleWidth,
+                            child: fullDayEventBuilder.call(
+                              fullDayEventList,
+                              dates[index],
+                            ),
+                          );
+                  },
                 )
               ],
             ),


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org