### PR TITLE
Added quarter hour indicator to DayView and both half hour indicator and quarter hour indicator to WeekView.

### DIFF
--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -93,7 +93,10 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
   final FullDayEventBuilder<T> fullDayEventBuilder;
 
   /// Flag to display half hours.
-  final bool showHalfHours;
+  final bool showHalfHours; 
+
+  /// Flag to display quarter hours.
+  final bool showQuarterHours;
 
   /// Settings for half hour indicator lines.
   final HourIndicatorSettings halfHourIndicatorSettings;
@@ -127,7 +130,8 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
     required this.fullDayEventBuilder,
     required this.scrollController,
     required this.dayDetectorBuilder,
-    required this.showHalfHours,
+    required this.showHalfHours, 
+    required this.showQuarterHours,
     required this.halfHourIndicatorSettings,
   }) : super(key: key);
 
@@ -168,6 +172,21 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
                       CustomPaint(
                         size: Size(width, height),
                         painter: HalfHourLinePainter(
+                          lineColor: halfHourIndicatorSettings.color,
+                          lineHeight: halfHourIndicatorSettings.height,
+                          offset:
+                              timeLineWidth + halfHourIndicatorSettings.offset,
+                          minuteHeight: heightPerMinute,
+                          lineStyle: halfHourIndicatorSettings.lineStyle,
+                          dashWidth: halfHourIndicatorSettings.dashWidth,
+                          dashSpaceWidth:
+                              halfHourIndicatorSettings.dashSpaceWidth,
+                        ),
+                      ), 
+                     if (showQuarterHours)
+                      CustomPaint(
+                        size: Size(width, height),
+                        painter: QuarterHourLinePainter(
                           lineColor: halfHourIndicatorSettings.color,
                           lineHeight: halfHourIndicatorSettings.height,
                           offset:

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -142,7 +142,7 @@ class DayView<T extends Object?> extends StatefulWidget {
   /// Defines offset of vertical line from hour line starts.
   final double verticalLineOffset;
 
-  /// Background colour of day view page.
+  /// Background color of day view page.
   final Color? backgroundColor;
 
   /// Scroll offset of day view page.
@@ -182,7 +182,11 @@ class DayView<T extends Object?> extends StatefulWidget {
   /// Display full day event builder.
   final FullDayEventBuilder<T>? fullDayEventBuilder;
 
+  /// Show half hour lines
   final bool showHalfHours;
+
+  /// Show quarter hour lines 
+  final bool showQuarterHours;
 
   /// Duration from where default day view will be visible
   /// By default it will be Duration(hours:0)
@@ -226,6 +230,7 @@ class DayView<T extends Object?> extends StatefulWidget {
     this.pageViewPhysics,
     this.dayDetectorBuilder,
     this.showHalfHours = false,
+    this.showQuarterHours = false,
     this.halfHourIndicatorSettings,
     this.startDuration = const Duration(hours: 0),
   })  : assert(timeLineOffset >= 0,
@@ -426,6 +431,7 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
                             fullDayEventBuilder: _fullDayEventBuilder,
                             scrollController: _scrollController,
                             showHalfHours: widget.showHalfHours,
+                            showQuarterHours: widget.showQuarterHours,
                             halfHourIndicatorSettings:
                                 _halfHourIndicatorSettings,
                           ),

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -182,10 +182,10 @@ class DayView<T extends Object?> extends StatefulWidget {
   /// Display full day event builder.
   final FullDayEventBuilder<T>? fullDayEventBuilder;
 
-  /// Show half hour lines
+  /// Show half hour indicator
   final bool showHalfHours;
 
-  /// Show quarter hour lines 
+  /// Show quarter hour indicator 
   final bool showQuarterHours;
 
   /// Duration from where default day view will be visible

--- a/lib/src/painters.dart
+++ b/lib/src/painters.dart
@@ -155,7 +155,88 @@ class HalfHourLinePainter extends CustomPainter {
             lineHeight != oldDelegate.lineHeight ||
             minuteHeight != oldDelegate.minuteHeight);
   }
+} 
+
+//using HalfHourIndicatorSettings for this too
+class QuarterHourLinePainter extends CustomPainter {
+  /// Color of quarter hour line
+  final Color lineColor;
+
+  /// Height of quarter hour line
+  final double lineHeight;
+
+  /// Offset of quarter hour line from left.
+  final double offset;
+
+  /// Height occupied by one minute of time stamp.
+  final double minuteHeight;
+
+  /// Style of the quarter hour line
+  final LineStyle lineStyle;
+
+  /// Line dash width when using the [LineStyle.dashed] style
+  final double dashWidth;
+
+  /// Line dash space width when using the [LineStyle.dashed] style
+  final double dashSpaceWidth;
+
+  /// Paint quarter hour lines
+  QuarterHourLinePainter({
+    required this.lineColor,
+    required this.lineHeight,
+    required this.offset,
+    required this.minuteHeight,
+    required this.lineStyle,
+    this.dashWidth = 4,
+    this.dashSpaceWidth = 4,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = lineColor
+      ..strokeWidth = lineHeight;
+
+    for (var i = 0; i < Constants.hoursADay; i++) {
+      final dy1 = i * minuteHeight * 60 + (minuteHeight * 15);
+      final dy2 = i * minuteHeight * 60 + (minuteHeight * 45);
+
+      //for the 15 minute line
+      if (lineStyle == LineStyle.dashed) {
+        var startX = offset;
+        while (startX < size.width) {
+          canvas.drawLine(
+              Offset(startX, dy1), Offset(startX + dashWidth, dy1), paint);
+          startX += dashWidth + dashSpaceWidth;
+        }
+      } else {
+        canvas.drawLine(Offset(offset, dy1), Offset(size.width, dy1), paint);
+      }
+
+      // for the 45 minutes line
+      if (lineStyle == LineStyle.dashed) {
+        var startX = offset;
+        while (startX < size.width) {
+          canvas.drawLine(
+              Offset(startX, dy2), Offset(startX + dashWidth, dy2), paint);
+          startX += dashWidth + dashSpaceWidth;
+        }
+      } else {
+        canvas.drawLine(Offset(offset, dy2), Offset(size.width, dy2), paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return oldDelegate is HourLinePainter &&
+        (oldDelegate.lineColor != lineColor ||
+            oldDelegate.offset != offset ||
+            lineHeight != oldDelegate.lineHeight ||
+            minuteHeight != oldDelegate.minuteHeight);
+  }
 }
+
 
 /// Paints a single horizontal line at [offset].
 class CurrentTimeLinePainter extends CustomPainter {

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -37,6 +37,9 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
   /// Settings for hour indicator lines.
   final HourIndicatorSettings hourIndicatorSettings;
 
+  /// Settings for half hour indicator lines. 
+  final HourIndicatorSettings halfHourIndicatorSettings;
+
   /// Flag to display live line.
   final bool showLiveLine;
 
@@ -111,6 +114,12 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
   /// Display full day events.
   final FullDayEventBuilder<T> fullDayEventBuilder;
 
+  /// Flag to display half hours
+  final bool showHalfHours; 
+
+  /// Flag to display quarter hours 
+  final bool showQuarterHours; 
+
   /// A single page for week view.
   const InternalWeekViewPage({
     Key? key,
@@ -123,7 +132,8 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
     required this.eventTileBuilder,
     required this.controller,
     required this.timeLineBuilder,
-    required this.hourIndicatorSettings,
+    required this.hourIndicatorSettings, 
+    required this.halfHourIndicatorSettings,
     required this.showLiveLine,
     required this.liveTimeIndicatorSettings,
     required this.heightPerMinute,
@@ -143,6 +153,8 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
     required this.scrollConfiguration,
     required this.fullDayEventBuilder,
     required this.weekDetectorBuilder,
+    required this.showHalfHours, 
+    required this.showQuarterHours,
   }) : super(key: key);
 
   @override
@@ -225,6 +237,36 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                         showVerticalLine: showVerticalLine,
                       ),
                     ),
+                          if (showHalfHours)
+                      CustomPaint(
+                        size: Size(width, height),
+                        painter: HalfHourLinePainter(
+                          lineColor: halfHourIndicatorSettings.color,
+                          lineHeight: halfHourIndicatorSettings.height,
+                          offset:
+                              timeLineWidth + halfHourIndicatorSettings.offset,
+                          minuteHeight: heightPerMinute,
+                          lineStyle: halfHourIndicatorSettings.lineStyle,
+                          dashWidth: halfHourIndicatorSettings.dashWidth,
+                          dashSpaceWidth:
+                              halfHourIndicatorSettings.dashSpaceWidth,
+                        ),
+                      ), 
+                     if (showQuarterHours)
+                      CustomPaint(
+                        size: Size(width, height),
+                        painter: QuarterHourLinePainter(
+                          lineColor: halfHourIndicatorSettings.color,
+                          lineHeight: halfHourIndicatorSettings.height,
+                          offset:
+                              timeLineWidth + halfHourIndicatorSettings.offset,
+                          minuteHeight: heightPerMinute,
+                          lineStyle: halfHourIndicatorSettings.lineStyle,
+                          dashWidth: halfHourIndicatorSettings.dashWidth,
+                          dashSpaceWidth:
+                              halfHourIndicatorSettings.dashSpaceWidth,
+                        ),
+                      ),
                     if (showLiveLine && liveTimeIndicatorSettings.height > 0)
                       LiveTimeIndicator(
                         liveTimeIndicatorSettings: liveTimeIndicatorSettings,

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -85,6 +85,9 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// Settings for hour indicator settings.
   final HourIndicatorSettings? hourIndicatorSettings;
 
+  /// Settings for half hour and quarter hour indicator settings.
+  final HourIndicatorSettings? halfHourIndicatorSettings;
+
   /// Settings for live time indicator settings.
   final HourIndicatorSettings? liveTimeIndicatorSettings;
 
@@ -175,13 +178,19 @@ class WeekView<T extends Object?> extends StatefulWidget {
   final MinuteSlotSize minuteSlotSize;
 
   /// Style for WeekView header.
-  final HeaderStyle headerStyle;
+  final HeaderStyle headerStyle;  
 
   /// Option for SafeArea.
   final SafeAreaOption safeAreaOption;
 
   /// Display full day event builder.
   final FullDayEventBuilder<T>? fullDayEventBuilder;
+
+  ///Show half hour indicator 
+  final bool showHalfHours; 
+
+  ///Show quarter hour indicator 
+  final bool showQuarterHours;
 
   /// Main widget for week view.
   const WeekView({
@@ -198,6 +207,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
     this.maxDay,
     this.initialDay,
     this.hourIndicatorSettings,
+    this.halfHourIndicatorSettings,
     this.timeLineBuilder,
     this.timeLineWidth,
     this.liveTimeIndicatorSettings,
@@ -224,6 +234,8 @@ class WeekView<T extends Object?> extends StatefulWidget {
     this.headerStyle = const HeaderStyle(),
     this.safeAreaOption = const SafeAreaOption(),
     this.fullDayEventBuilder,
+    this.showHalfHours = false, 
+    this.showQuarterHours = false,
   })  : assert((timeLineOffset) >= 0,
             "timeLineOffset must be greater than or equal to 0"),
         assert(width == null || width > 0,
@@ -258,7 +270,8 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
 
   late EventArranger<T> _eventArranger;
 
-  late HourIndicatorSettings _hourIndicatorSettings;
+  late HourIndicatorSettings _hourIndicatorSettings; 
+  late HourIndicatorSettings _halfHourIndicatorSettings;
   late HourIndicatorSettings _liveTimeIndicatorSettings;
 
   late PageController _pageController;
@@ -418,6 +431,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                             eventTileBuilder: _eventTileBuilder,
                             heightPerMinute: widget.heightPerMinute,
                             hourIndicatorSettings: _hourIndicatorSettings,
+                            halfHourIndicatorSettings: _halfHourIndicatorSettings,
                             dates: dates,
                             showLiveLine: widget.showLiveTimeLineInAllDays ||
                                 _showLiveTimeIndicator(dates),
@@ -433,6 +447,8 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                             minuteSlotSize: widget.minuteSlotSize,
                             scrollConfiguration: _scrollConfiguration,
                             fullDayEventBuilder: _fullDayEventBuilder,
+                            showHalfHours: widget.showHalfHours, 
+                            showQuarterHours: widget.showQuarterHours,
                           ),
                         );
                       },
@@ -510,6 +526,13 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     _weekTitleWidth =
         (_width - _timeLineWidth - _hourIndicatorSettings.offset) /
             _totalDaysInWeek;
+
+    _halfHourIndicatorSettings = widget.halfHourIndicatorSettings ?? 
+      HourIndicatorSettings(
+          height: widget.heightPerMinute,
+          color: Constants.defaultBorderColor,
+          offset: 5,
+        );
   }
 
   void _calculateHeights() {


### PR DESCRIPTION
# Description
<!--
Previously, on DayView, we couldn't use quarter hour indicators. But this commit provides a showQuarterHours bool parameter that enables quarter hour indicators. The quarter hour indicators use halfHourIndicatorSettings only. 

Previously, on WeekView, we couldn't use half hour and quarter hour indicators. Also, there was no option for halfHourIndicatorSettings. The new api uses the halfHourIndicatorSettings and bool values to enable both half hour and quarter hour indicators.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Closes #270
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org