### PR TITLE
fix: Customize ScrollPhysics for MonthView

### DIFF
--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -138,6 +138,12 @@ class MonthView<T extends Object?> extends StatefulWidget {
   /// Option for SafeArea.
   final SafeAreaOption safeAreaOption;
 
+  /// Defines scroll physics for a page of a month view.
+  ///
+  /// This can be used to disable the vertical scroll of a page.
+  /// Default value is [ClampingScrollPhysics].
+  final ScrollPhysics pagePhysics;
+
   /// Main [Widget] to display month view.
   const MonthView({
     Key? key,
@@ -166,6 +172,7 @@ class MonthView<T extends Object?> extends StatefulWidget {
     this.weekDayStringBuilder,
     this.headerStyle = const HeaderStyle(),
     this.safeAreaOption = const SafeAreaOption(),
+    this.pagePhysics = const ClampingScrollPhysics(),
   }) : super(key: key);
 
   @override
@@ -343,6 +350,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
                               date: date,
                               showBorder: widget.showBorder,
                               startDay: widget.startDay,
+                              physics: widget.pagePhysics,
                             ),
                           );
                         }),
@@ -588,6 +596,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
   final CellTapCallback<T>? onCellTap;
   final DatePressCallback? onDateLongPress;
   final WeekDays startDay;
+  final ScrollPhysics physics;
 
   const _MonthPageBuilder({
     Key? key,
@@ -603,6 +612,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
     required this.onCellTap,
     required this.onDateLongPress,
     required this.startDay,
+    required this.physics,
   }) : super(key: key);
 
   @override
@@ -613,7 +623,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
       height: height,
       child: GridView.builder(
         padding: EdgeInsets.zero,
-        physics: ClampingScrollPhysics(),
+        physics: physics,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: 7,
           childAspectRatio: cellRatio,


### PR DESCRIPTION
# Description
This change allows for adding a specific `ScrollPhysics` to the month view, for the month view's pages.
In my case, I have the `MonthView` nested somewhere in a sliver of a `CustomScrollView` and the month view page's `GridView` suddenly takes the "scroll focus" while I just want it never to scroll. This option allows me to pass in a `NeverScrollableScrollPhysics` which fixes the issue.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
No breaking changes

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

Fixes #178 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org