### PR TITLE
:fix: Improve the LiveTimeIndicator performance.

### DIFF
--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -51,14 +51,13 @@ class LiveTimeIndicator extends StatefulWidget {
 
 class _LiveTimeIndicatorState extends State<LiveTimeIndicator> {
   late Timer _timer;
-  late DateTime _currentDate;
+  late TimeOfDay _currentTime = TimeOfDay.now();
 
   @override
   void initState() {
     super.initState();
 
-    _currentDate = DateTime.now();
-    _timer = Timer(Duration(seconds: 1), setTimer);
+    _timer = Timer.periodic(Duration(seconds: 1), _onTick);
   }
 
   @override
@@ -70,12 +69,11 @@ class _LiveTimeIndicatorState extends State<LiveTimeIndicator> {
   /// Creates an recursive call that runs every 1 seconds.
   /// This will rebuild TimeLineIndicator every second. This will allow us
   /// to indicate live time in Week and Day view.
-  void setTimer() {
-    if (mounted) {
-      setState(() {
-        _currentDate = DateTime.now();
-        _timer = Timer(Duration(seconds: 1), setTimer);
-      });
+  void _onTick(Timer? timer) {
+    final time = TimeOfDay.now();
+    if (time != _currentTime && mounted) {
+      _currentTime = time;
+      setState(() {});
     }
   }
 
@@ -88,7 +86,7 @@ class _LiveTimeIndicatorState extends State<LiveTimeIndicator> {
         height: widget.liveTimeIndicatorSettings.height,
         offset: Offset(
           widget.timeLineWidth + widget.liveTimeIndicatorSettings.offset,
-          _currentDate.getTotalMinutes * widget.heightPerMinute,
+          _currentTime.getTotalMinutes * widget.heightPerMinute,
         ),
       ),
     );

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -184,3 +184,7 @@ extension MyList on List<CalendarEventData> {
     }
   }
 }
+
+extension TimerOfDayExtension on TimeOfDay {
+  int get getTotalMinutes => hour * 60 + minute;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.22.0
 
 flutter:

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -1,5 +1,5 @@
 import 'package:calendar_view/calendar_view.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('DateTimeExtensions', () {


### PR DESCRIPTION
Improve the LiveTimeIndicator to set the state only when the current hour and minute changes.

# Description
This PR removes unnecessary rebuilds every second. Instead, it will only rebuild the timeline when the current hour or minute will change.


## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
None