### PR TITLE
:feat: Adds includeEdge flag in EventArrangers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,15 @@
 # [1.0.5] (UnReleased)(https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.0.5)
 
 - Fixed issue related to auto scroll to initial duration for day
-  view-[#269](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/269)
+  view. [#269](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/269)
 - Added
-  feature added a callback for the default header title
-    - [#241](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/241)
+  feature added a callback for the default header title. [#241](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/241)
 - Added
   feature added the quarterHourIndicator for the DayView & halfHourIndicator and
-  quarterHourIndicator for WeekView
-    - [#270](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/270)
+  quarterHourIndicator for WeekView. [#270](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/270)
 - Added
-  feature added Support for changing the week day position(top/bottom) in weekView
-  - [#283](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/283)
+  feature added Support for changing the week day position(top/bottom) in weekView. [#283](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/283)
+- Adds new flag `includeEdges` in `EventArrangers`. [#290](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/pull/294)
 
 # [1.0.4 - 9 Aug 2023](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.0.4)
 

--- a/lib/src/calendar_event_data.dart
+++ b/lib/src/calendar_event_data.dart
@@ -70,7 +70,7 @@ class CalendarEventData<T extends Object?> {
       };
 
   @override
-  String toString() => toJson().toString();
+  String toString() => '${toJson()}';
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/event_arrangers/event_arrangers.dart
+++ b/lib/src/event_arrangers/event_arrangers.dart
@@ -14,6 +14,12 @@ part 'merge_event_arranger.dart';
 
 part 'side_event_arranger.dart';
 
+/// {@template event_arranger_arrange_method_doc}
+/// This method will arrange all the events in and return List of
+/// [OrganizedCalendarEventData].
+///
+/// {@endtemplate}
+
 abstract class EventArranger<T extends Object?> {
   /// [EventArranger] defines how simultaneous events will be arranged.
   /// Implement [arrange] method to define how events will be arranged.
@@ -24,9 +30,7 @@ abstract class EventArranger<T extends Object?> {
   ///
   const EventArranger();
 
-  /// This method will arrange all the events in and return List of
-  /// [OrganizedCalendarEventData].
-  ///
+  /// {@macro event_arranger_arrange_method_doc}
   List<OrganizedCalendarEventData<T>> arrange({
     required List<CalendarEventData<T>> events,
     required double height,

--- a/lib/src/event_arrangers/side_event_arranger.dart
+++ b/lib/src/event_arrangers/side_event_arranger.dart
@@ -7,8 +7,22 @@ part of 'event_arrangers.dart';
 class SideEventArranger<T extends Object?> extends EventArranger<T> {
   /// This class will provide method that will arrange
   /// all the events side by side.
-  const SideEventArranger();
+  const SideEventArranger({
+    this.includeEdges = false,
+  });
 
+  /// Decides whether events that are overlapping on edge
+  /// (ex, event1 has the same end-time as the start-time of event 2)
+  /// should be offset or not.
+  ///
+  /// If includeEdges is true, it will offset the events else it will not.
+  ///
+  final bool includeEdges;
+
+  /// {@macro event_arranger_arrange_method_doc}
+  ///
+  /// Make sure that all the events that are passed in [events], must be in
+  /// ascending order of start time.
   @override
   List<OrganizedCalendarEventData<T>> arrange({
     required List<CalendarEventData<T>> events,
@@ -16,7 +30,9 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     required double width,
     required double heightPerMinute,
   }) {
-    final mergedEvents = MergeEventArranger<T>().arrange(
+    final mergedEvents = MergeEventArranger<T>(
+      includeEdges: includeEdges,
+    ).arrange(
       events: events,
       height: height,
       width: width,

--- a/test/event_arranger_test/merge_event_arranger_test.dart
+++ b/test/event_arranger_test/merge_event_arranger_test.dart
@@ -1,0 +1,473 @@
+import 'package:calendar_view/calendar_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const height = 1440.0;
+const width = 500.0;
+const heightPerMinute = 1.0;
+
+void main() {
+  final now = DateTime.now().withoutTime;
+
+  group('MergeEventArrangerTest', () {
+    test('Events which does not overlap.', () {
+      final events = [
+        CalendarEventData(
+          title: 'Event 1',
+          date: now,
+          startTime: now.add(Duration(hours: 1)),
+          endTime: now.add(
+            Duration(hours: 2),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 2',
+          date: now,
+          startTime: now.add(Duration(hours: 2, minutes: 15)),
+          endTime: now.add(
+            Duration(hours: 3),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 3',
+          date: now,
+          startTime: now.add(Duration(hours: 3, minutes: 15)),
+          endTime: now.add(
+            Duration(hours: 4),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 4',
+          date: now,
+          startTime: now.add(Duration(hours: 4, minutes: 15)),
+          endTime: now.add(
+            Duration(hours: 5),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 5',
+          date: now,
+          startTime: now.add(Duration(hours: 10)),
+          endTime: now.add(
+            Duration(hours: 13),
+          ),
+        ),
+      ];
+
+      final mergedEvents = MergeEventArranger().arrange(
+        events: events,
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+      );
+
+      expect(mergedEvents.length, events.length);
+    });
+    test('Only start time is overlapping', () {
+      final events = [
+        CalendarEventData(
+          title: 'Event 1',
+          date: now,
+          startTime: now.add(Duration(hours: 10)),
+          endTime: now.add(
+            Duration(hours: 12),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 2',
+          date: now,
+          startTime: now.add(Duration(hours: 8)),
+          endTime: now.add(
+            Duration(hours: 10),
+          ),
+        ),
+      ];
+
+      final mergedEvents = MergeEventArranger().arrange(
+        events: events,
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+      );
+
+      expect(mergedEvents.length, 1);
+    });
+    test('Only end time is overlapping', () {
+      final events = [
+        CalendarEventData(
+          title: 'Event 1',
+          date: now,
+          startTime: now.add(Duration(hours: 8)),
+          endTime: now.add(
+            Duration(hours: 10),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 2',
+          date: now,
+          startTime: now.add(Duration(hours: 10)),
+          endTime: now.add(
+            Duration(hours: 12),
+          ),
+        ),
+      ];
+
+      final mergedEvents = MergeEventArranger().arrange(
+        events: events,
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+      );
+
+      expect(mergedEvents.length, 1);
+    });
+    test('Event1 is smaller than event 2 and overlapping', () {
+      final events = [
+        CalendarEventData(
+          title: 'Event 1',
+          date: now,
+          startTime: now.add(Duration(hours: 10)),
+          endTime: now.add(
+            Duration(hours: 12),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 2',
+          date: now,
+          startTime: now.add(Duration(hours: 8)),
+          endTime: now.add(
+            Duration(hours: 14),
+          ),
+        ),
+      ];
+
+      final mergedEvents = MergeEventArranger().arrange(
+        events: events,
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+      );
+
+      expect(mergedEvents.length, 1);
+    });
+    test('Event2 is smaller than event 1 and overlapping', () {
+      final events = [
+        CalendarEventData(
+          title: 'Event 1',
+          date: now,
+          startTime: now.add(Duration(hours: 8)),
+          endTime: now.add(
+            Duration(hours: 14),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 2',
+          date: now,
+          startTime: now.add(Duration(hours: 10)),
+          endTime: now.add(
+            Duration(hours: 12),
+          ),
+        ),
+      ];
+
+      final mergedEvents = MergeEventArranger().arrange(
+        events: events,
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+      );
+
+      expect(mergedEvents.length, 1);
+    });
+    test('Both events are of same duration and occurs at the same time', () {
+      final events = [
+        CalendarEventData(
+          title: 'Event 1',
+          date: now,
+          startTime: now.add(Duration(hours: 10)),
+          endTime: now.add(
+            Duration(hours: 12),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 2',
+          date: now,
+          startTime: now.add(Duration(hours: 10)),
+          endTime: now.add(
+            Duration(hours: 12),
+          ),
+        ),
+      ];
+
+      final mergedEvents = MergeEventArranger().arrange(
+        events: events,
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+      );
+
+      expect(mergedEvents.length, 1);
+    });
+    test('Only few events overlaps', () {
+      final events = [
+        CalendarEventData(
+          title: 'Event 1',
+          date: now,
+          startTime: now.add(Duration(hours: 1)),
+          endTime: now.add(
+            Duration(hours: 2),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 4',
+          date: now,
+          startTime: now.add(Duration(hours: 7)),
+          endTime: now.add(
+            Duration(hours: 11),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 6',
+          date: now,
+          startTime: now.add(Duration(hours: 3)),
+          endTime: now.add(
+            Duration(hours: 3, minutes: 30),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 5',
+          date: now,
+          startTime: now.add(Duration(hours: 1, minutes: 15)),
+          endTime: now.add(
+            Duration(hours: 2, minutes: 15),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 3',
+          date: now,
+          startTime: now.add(Duration(hours: 5)),
+          endTime: now.add(
+            Duration(hours: 6),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 2',
+          date: now,
+          startTime: now.add(Duration(hours: 8)),
+          endTime: now.add(
+            Duration(hours: 9),
+          ),
+        ),
+      ];
+
+      final mergedEvents = MergeEventArranger().arrange(
+        events: events,
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+      );
+
+      expect(mergedEvents.length, 4);
+    });
+    test('All events overlaps with each other', () {
+      final events = [
+        CalendarEventData(
+          title: 'Event 1',
+          date: now,
+          startTime: now.add(Duration(hours: 1)),
+          endTime: now.add(
+            Duration(hours: 2),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 2',
+          date: now,
+          startTime: now.add(Duration(hours: 4)),
+          endTime: now.add(
+            Duration(hours: 5),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 3',
+          date: now,
+          startTime: now.add(Duration(hours: 2)),
+          endTime: now.add(
+            Duration(hours: 6),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 4',
+          date: now,
+          startTime: now.add(Duration(hours: 7)),
+          endTime: now.add(
+            Duration(hours: 10),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 5',
+          date: now,
+          startTime: now.add(Duration(hours: 5)),
+          endTime: now.add(
+            Duration(hours: 7),
+          ),
+        ),
+        CalendarEventData(
+          title: 'Event 6',
+          date: now,
+          startTime: now.add(Duration(hours: 3)),
+          endTime: now.add(
+            Duration(hours: 6),
+          ),
+        ),
+      ];
+
+      final mergedEvents = MergeEventArranger().arrange(
+        events: events
+          ..sort((e1, e2) =>
+              (e1.startTime?.getTotalMinutes ?? 0) -
+              (e2.startTime?.getTotalMinutes ?? 0)),
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+      );
+
+      expect(mergedEvents.length, 1);
+    });
+
+    group('Edge event should not merge', () {
+      test('End of Event 1 and Start of Event 2 is same', () {
+        final events = [
+          CalendarEventData(
+            title: 'Event 1',
+            date: now,
+            startTime: now.add(Duration(hours: 1)),
+            endTime: now.add(
+              Duration(hours: 2),
+            ),
+          ),
+          CalendarEventData(
+            title: 'Event 2',
+            date: now,
+            startTime: now.add(Duration(hours: 2)),
+            endTime: now.add(
+              Duration(hours: 3),
+            ),
+          ),
+        ];
+
+        final mergedEvents = MergeEventArranger(includeEdges: false).arrange(
+          events: events
+            ..sort((e1, e2) =>
+                (e1.startTime?.getTotalMinutes ?? 0) -
+                (e2.startTime?.getTotalMinutes ?? 0)),
+          height: height,
+          width: width,
+          heightPerMinute: heightPerMinute,
+        );
+
+        expect(mergedEvents.length, 2);
+      });
+
+      test('Start of Event 1 and End of Event 2 is same', () {
+        final events = [
+          CalendarEventData(
+            title: 'Event 1',
+            date: now,
+            startTime: now.add(Duration(hours: 2)),
+            endTime: now.add(
+              Duration(hours: 3),
+            ),
+          ),
+          CalendarEventData(
+            title: 'Event 2',
+            date: now,
+            startTime: now.add(Duration(hours: 1)),
+            endTime: now.add(
+              Duration(hours: 2),
+            ),
+          ),
+        ];
+
+        final mergedEvents = MergeEventArranger(includeEdges: false).arrange(
+          events: events
+            ..sort((e1, e2) =>
+                (e1.startTime?.getTotalMinutes ?? 0) -
+                (e2.startTime?.getTotalMinutes ?? 0)),
+          height: height,
+          width: width,
+          heightPerMinute: heightPerMinute,
+        );
+
+        expect(mergedEvents.length, 2);
+      });
+    });
+    group('Edge event should merge', () {
+      test('End of Event 1 and Start of Event 2 is same', () {
+        final events = [
+          CalendarEventData(
+            title: 'Event 1',
+            date: now,
+            startTime: now.add(Duration(hours: 1)),
+            endTime: now.add(
+              Duration(hours: 2),
+            ),
+          ),
+          CalendarEventData(
+            title: 'Event 2',
+            date: now,
+            startTime: now.add(Duration(hours: 2)),
+            endTime: now.add(
+              Duration(hours: 3),
+            ),
+          ),
+        ];
+
+        final mergedEvents = MergeEventArranger(includeEdges: true).arrange(
+          events: events
+            ..sort((e1, e2) =>
+                (e1.startTime?.getTotalMinutes ?? 0) -
+                (e2.startTime?.getTotalMinutes ?? 0)),
+          height: height,
+          width: width,
+          heightPerMinute: heightPerMinute,
+        );
+
+        expect(mergedEvents.length, 1);
+      });
+
+      test('Start of Event 1 and End of Event 2 is same', () {
+        final events = [
+          CalendarEventData(
+            title: 'Event 1',
+            date: now,
+            startTime: now.add(Duration(hours: 2)),
+            endTime: now.add(
+              Duration(hours: 3),
+            ),
+          ),
+          CalendarEventData(
+            title: 'Event 2',
+            date: now,
+            startTime: now.add(Duration(hours: 1)),
+            endTime: now.add(
+              Duration(hours: 2),
+            ),
+          ),
+        ];
+
+        final mergedEvents = MergeEventArranger(includeEdges: true).arrange(
+          events: events
+            ..sort((e1, e2) =>
+                (e1.startTime?.getTotalMinutes ?? 0) -
+                (e2.startTime?.getTotalMinutes ?? 0)),
+          height: height,
+          width: width,
+          heightPerMinute: heightPerMinute,
+        );
+
+        expect(mergedEvents.length, 1);
+      });
+    });
+
+// TODO: add tests for the events where start or end time is not valid.
+  });
+}


### PR DESCRIPTION
# Description
This PR Adds the option to decide whether to include the edge while merging the overlapping events or not. It adds a new flag `includeEdge` in `MergeEventArranger` and `SideEventArranger` that will decide whether the events that overlaps on the edge should be merged or not. I've attached 2 image of `SideEventArranger` one with `includeEdge` true another with false.

includeEdge: true
<img width="495" alt="includeEdge_Is_True" src="https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/assets/75968805/388e4c61-a1a2-4fed-8131-c2bd82a4cd45">

includeEdge: false
<img width="492" alt="includeEdge_Is_False" src="https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/assets/75968805/c9900fdd-b46c-4583-a788-a2119bff6083">


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
This will fix the issue #290 .