### PR TITLE
✨ Removes force unwrap while sorting the events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added
   feature added Support for changing the week day position(top/bottom) in weekView. [#283](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/283)
 - Adds new flag `includeEdges` in `EventArrangers`. [#290](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/pull/294)
+- Fixes null check exception while adding events. [#282](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/282)
 
 # [1.0.4 - 9 Aug 2023](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.0.4)
 

--- a/lib/src/event_controller.dart
+++ b/lib/src/event_controller.dart
@@ -159,7 +159,9 @@ class EventController<T extends Object?> extends ChangeNotifier {
         'The end date must be greater or equal to the start date');
     if (_calendarData.eventList.contains(event)) return;
     if (event.endDate.difference(event.date).inDays > 0) {
-      if (event.startTime!.isDayStart && event.endTime!.isDayStart) {
+      if (event.startTime == null ||
+          event.endTime == null ||
+          (event.startTime!.isDayStart && event.endTime!.isDayStart)) {
         _calendarData.fullDayEventList.addEventInSortedManner(event);
       } else {
         _calendarData.rangingEventList.addEventInSortedManner(event);

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -170,17 +170,20 @@ extension MyList on List<CalendarEventData> {
   // the existing list of CalendarEventData.
   void addEventInSortedManner(CalendarEventData event) {
     var addIndex = -1;
+
     for (var i = 0; i < this.length; i++) {
-      if (event.startTime!.compareTo(this[i].startTime!) <= 0) {
+      if ((event.startTime?.getTotalMinutes ?? 0) -
+              (this[i].startTime?.getTotalMinutes ?? 0) <=
+          0) {
         addIndex = i;
         break;
       }
     }
 
     if (addIndex > -1) {
-      this.insert(addIndex, event);
+      insert(addIndex, event);
     } else {
-      this.add(event);
+      add(event);
     }
   }
 }


### PR DESCRIPTION

# Description
Removes the force unwrap on `startTime` in `addEventInSortedManner` method of `MyList` extension. This will fix the issue that was occurring while adding the events without `startTime`.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Fixes issue #282 .