### PR TITLE
feat: [Week View] Option to set the all day events header row title

### DIFF
--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -191,7 +191,7 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
             child: Container(
               decoration: BoxDecoration(
                 border: Border(
-                  bottom: BorderSide(color: Constants.defaultBorderColor, width: 2),
+                  bottom: BorderSide(color: hourIndicatorSettings.color, width: 2),
                 ),
               ),
               child: Row(

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -192,15 +192,13 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                   (index) {
                     final fullDayEventList =
                         controller.getFullDayEvent(filteredDates[index]);
-                    return fullDayEventList.isEmpty
-                        ? SizedBox.shrink()
-                        : SizedBox(
-                            width: weekTitleWidth,
-                            child: fullDayEventBuilder.call(
-                              fullDayEventList,
-                              dates[index],
-                            ),
-                          );
+                    return SizedBox(
+                      width: weekTitleWidth,
+                      child: fullDayEventBuilder.call(
+                        fullDayEventList,
+                        dates[index],
+                      ),
+                    );
                   },
                 )
               ],

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -12,6 +12,7 @@ import '../event_controller.dart';
 import '../modals.dart';
 import '../painters.dart';
 import '../typedefs.dart';
+import '../constants.dart';
 
 /// A single page for week view.
 class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
@@ -111,6 +112,9 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
   /// Display full day events.
   final FullDayEventBuilder<T> fullDayEventBuilder;
 
+  /// Title of the full day events row
+  final String? fullDayHeaderTitle;
+
   /// A single page for week view.
   const InternalWeekViewPage({
     Key? key,
@@ -143,6 +147,7 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
     required this.scrollConfiguration,
     required this.fullDayEventBuilder,
     required this.weekDetectorBuilder,
+    this.fullDayHeaderTitle,
   }) : super(key: key);
 
   @override
@@ -183,25 +188,44 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
           ),
           SizedBox(
             width: width,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SizedBox(width: timeLineWidth + hourIndicatorSettings.offset),
-                ...List.generate(
-                  filteredDates.length,
-                  (index) {
-                    final fullDayEventList =
-                        controller.getFullDayEvent(filteredDates[index]);
-                    return SizedBox(
-                      width: weekTitleWidth,
-                      child: fullDayEventBuilder.call(
-                        fullDayEventList,
-                        dates[index],
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(color: Constants.defaultBorderColor, width: 2),
+                ),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: timeLineWidth + hourIndicatorSettings.offset,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 1),
+                      child: Text(
+                        fullDayHeaderTitle ?? "",
+                        textAlign: TextAlign.center,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                    );
-                  },
-                )
-              ],
+                    ),
+                  ),
+                  ...List.generate(
+                    filteredDates.length,
+                        (index) {
+                      final fullDayEventList = controller.getFullDayEvent(filteredDates[index]);
+                      return Container(
+                        width: weekTitleWidth,
+                        child: fullDayEventList.isEmpty
+                            ? null
+                            : fullDayEventBuilder.call(
+                          fullDayEventList,
+                          dates[index],
+                        ),
+                      );
+                    },
+                  )
+                ],
+              ),
             ),
           ),
           Expanded(

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -247,14 +247,7 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                         showVerticalLine: showVerticalLine,
                       ),
                     ),
-                    if (showLiveLine && liveTimeIndicatorSettings.height > 0)
-                      LiveTimeIndicator(
-                        liveTimeIndicatorSettings: liveTimeIndicatorSettings,
-                        width: width,
-                        height: height,
-                        heightPerMinute: heightPerMinute,
-                        timeLineWidth: timeLineWidth,
-                      ),
+
                     Align(
                       alignment: Alignment.centerRight,
                       child: SizedBox(
@@ -311,6 +304,14 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                       timeLineOffset: timeLineOffset,
                       timeLineBuilder: timeLineBuilder,
                     ),
+                    if (showLiveLine && liveTimeIndicatorSettings.height > 0)
+                      LiveTimeIndicator(
+                        liveTimeIndicatorSettings: liveTimeIndicatorSettings,
+                        width: width,
+                        height: height,
+                        heightPerMinute: heightPerMinute,
+                        timeLineWidth: timeLineWidth,
+                      ),
                   ],
                 ),
               ),

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -247,7 +247,6 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                         showVerticalLine: showVerticalLine,
                       ),
                     ),
-
                     Align(
                       alignment: Alignment.centerRight,
                       child: SizedBox(
@@ -305,12 +304,14 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                       timeLineBuilder: timeLineBuilder,
                     ),
                     if (showLiveLine && liveTimeIndicatorSettings.height > 0)
-                      LiveTimeIndicator(
-                        liveTimeIndicatorSettings: liveTimeIndicatorSettings,
-                        width: width,
-                        height: height,
-                        heightPerMinute: heightPerMinute,
-                        timeLineWidth: timeLineWidth,
+                      IgnorePointer(
+                        child: LiveTimeIndicator(
+                          liveTimeIndicatorSettings: liveTimeIndicatorSettings,
+                          width: width,
+                          height: height,
+                          heightPerMinute: heightPerMinute,
+                          timeLineWidth: timeLineWidth,
+                        ),
                       ),
                   ],
                 ),

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -183,6 +183,9 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// Display full day event builder.
   final FullDayEventBuilder<T>? fullDayEventBuilder;
 
+  /// Title of the full day events row
+  final String? fullDayHeaderTitle;
+
   /// Main widget for week view.
   const WeekView({
     Key? key,
@@ -224,6 +227,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
     this.headerStyle = const HeaderStyle(),
     this.safeAreaOption = const SafeAreaOption(),
     this.fullDayEventBuilder,
+    this.fullDayHeaderTitle,
   })  : assert((timeLineOffset) >= 0,
             "timeLineOffset must be greater than or equal to 0"),
         assert(width == null || width > 0,
@@ -255,6 +259,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
   late DateTime _currentWeek;
   late int _totalWeeks;
   late int _currentIndex;
+  late String? _fullDayHeaderTitle;
 
   late EventArranger<T> _eventArranger;
 
@@ -306,6 +311,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     _eventArranger = widget.eventArranger ?? SideEventArranger<T>();
 
     _assignBuilders();
+    _fullDayHeaderTitle = widget.fullDayHeaderTitle;
   }
 
   @override
@@ -433,6 +439,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                             minuteSlotSize: widget.minuteSlotSize,
                             scrollConfiguration: _scrollConfiguration,
                             fullDayEventBuilder: _fullDayEventBuilder,
+                            fullDayHeaderTitle: _fullDayHeaderTitle,
                           ),
                         );
                       },


### PR DESCRIPTION
# Description
Allow user to set a title for the full day row on week view.
New option name: `fullDayHeaderTitle`
![image](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/assets/43602260/7e346b81-11f6-43ae-a240-ee29af793675)

## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
#308 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org