### PR TITLE
fix: 🐛Header view hidden functionality added #299.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # [1.0.5] (UnReleased)
-
+- Fixed issue related to Hiding Header [#299](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/pull/299)
 - Fixed issue related to auto scroll to initial duration for day
   view. [#269](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/269)
 - Added

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ MonthView(
     // This callback will only work if cellBuilder is null.
     onEventTap: (event, date) => print(event),
     onDateLongPress: (date) => print(date),
+    headerBuilder: MonthHeader.hidden // To hide month header
 );
 ```
 
@@ -177,7 +178,8 @@ DayView(
     startHour: 5 // To set the first hour displayed (ex: 05:00)
     hourLinePainter: (lineColor, lineHeight, offset, minuteHeight, showVerticalLine, verticalLineOffset) {
         return //Your custom painter.
-    }
+    },
+    dayTitleBuilder: DayHeader.hidden // To Hide day header
 );
 ```
 
@@ -208,7 +210,8 @@ WeekView(
     showVerticalLines: false, // Show the vertical line between days.
     hourLinePainter: (lineColor, lineHeight, offset, minuteHeight, showVerticalLine, verticalLineOffset) {
         return //Your custom painter.
-    }
+    },
+    weekPageHeaderBuilder: WeekHeader.hidden // To hide week header
 );
 ```
 

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -911,3 +911,8 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   DateTime get currentDate =>
       DateTime(_currentDate.year, _currentDate.month, _currentDate.day);
 }
+
+class DayHeader {
+  /// Hide Header Widget
+  static Widget hidden(DateTime date) => SizedBox.shrink();
+}

--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -667,3 +667,8 @@ class _MonthPageBuilder<T> extends StatelessWidget {
     );
   }
 }
+
+class MonthHeader {
+  /// Hide Header Widget
+  static Widget hidden(DateTime date) => SizedBox.shrink();
+}

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -1003,3 +1003,8 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
   bool _showLiveTimeIndicator(List<DateTime> dates) =>
       dates.any((date) => date.compareWithoutTime(DateTime.now()));
 }
+
+class WeekHeader {
+  /// Hide Header Widget
+  static Widget hidden(DateTime date, DateTime date1) => SizedBox.shrink();
+}


### PR DESCRIPTION
- In DayView, MonthView, and WeekView hidden methods are added for hiding header.

# Description

- In `MonthView` I added the class `MonthHeader`. Inside the `MonthHeader` class added a `hidden` method to hide the header widget. To hide a header inside the `MonthView` widget we can use like `headerBuilder: MonthHeader.hidden`.

- In `WeekView` I added the class `WeekHeader`. Inside the `WeekHeader` class added a `hidden` method to hide the header widget. To hide a header inside the `WeekView` widget we can use like `weekPageHeaderBuilder: WeekHeader.hidden`.

- In `DayView` I added the class `DayHeader`. Inside the `DayHeader` class added a `hidden` method to hide the header widget. To hide a header inside the `DayView` widget we can use like `dayTitleBuilder: DayHeader.hidden`.



## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
#299 


<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org