### PR TITLE
fix: 🐛hide month days not in current month functionality added #328.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [1.1.0 - 28 Feb 2024](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.1.0) 
+- Fixed issue related to Hiding Day which not in current month in MonthView. [#328](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/328)
 - Fixed issue related to Hiding Header [#299](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/pull/299)
 - Fixed issue related to auto scroll to initial duration for day
   view. [#269](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/269)

--- a/example/lib/widgets/month_view_widget.dart
+++ b/example/lib/widgets/month_view_widget.dart
@@ -18,6 +18,7 @@ class MonthViewWidget extends StatelessWidget {
     return MonthView(
       key: state,
       width: width,
+      hideDayNotInMonth: false,
       onEventTap: (event, date) {
         Navigator.of(context).push(
           MaterialPageRoute(

--- a/lib/src/components/month_view_components.dart
+++ b/lib/src/components/month_view_components.dart
@@ -98,6 +98,9 @@ class FilledCell<T extends Object?> extends StatelessWidget {
   /// color of highlighted cell title
   final Color highlightedTitleColor;
 
+  /// defines that show and hide cell not is in current month
+  final bool hideDayNotInMonth;
+
   /// This class will defines how cell will be displayed.
   /// This widget will display all the events as tile below date title.
   const FilledCell({
@@ -105,6 +108,7 @@ class FilledCell<T extends Object?> extends StatelessWidget {
     required this.date,
     required this.events,
     this.isInMonth = false,
+    this.hideDayNotInMonth = true,
     this.shouldHighlight = false,
     this.backgroundColor = Colors.blue,
     this.highlightColor = Colors.blue,
@@ -125,7 +129,9 @@ class FilledCell<T extends Object?> extends StatelessWidget {
           SizedBox(
             height: 5.0,
           ),
-          CircleAvatar(
+          (isInMonth == false && hideDayNotInMonth)
+              ? SizedBox.shrink()
+              : CircleAvatar(
             radius: highlightRadius,
             backgroundColor:
                 shouldHighlight ? highlightColor : Colors.transparent,

--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -147,6 +147,9 @@ class MonthView<T extends Object?> extends StatefulWidget {
   /// Default value is [ClampingScrollPhysics].
   final ScrollPhysics pagePhysics;
 
+  /// defines that show and hide cell not is in current month
+  final bool hideDayNotInMonth;
+
   /// Main [Widget] to display month view.
   const MonthView({
     Key? key,
@@ -177,6 +180,7 @@ class MonthView<T extends Object?> extends StatefulWidget {
     this.safeAreaOption = const SafeAreaOption(),
     this.onHeaderTitleTap,
     this.pagePhysics = const ClampingScrollPhysics(),
+    this.hideDayNotInMonth = false
   })  : assert(!(onHeaderTitleTap != null && headerBuilder != null),
             "can't use [onHeaderTitleTap] & [headerBuilder] simultaneously"),
         super(key: key);
@@ -357,6 +361,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
                               showBorder: widget.showBorder,
                               startDay: widget.startDay,
                               physics: widget.pagePhysics,
+                              hideDayNotInMonth: widget.hideDayNotInMonth,
                             ),
                           );
                         }),
@@ -508,7 +513,19 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
 
   /// Default cell builder. Used when [widget.cellBuilder] is null
   Widget _defaultCellBuilder(
-      date, List<CalendarEventData<T>> events, isToday, isInMonth) {
+      date, List<CalendarEventData<T>> events, isToday, isInMonth, hideDayNotInMonth) {
+    if(hideDayNotInMonth) {
+      return FilledCell<T>(
+        date: date,
+        shouldHighlight: isToday,
+        backgroundColor: isInMonth ? Constants.white : Constants.offWhite,
+        events: events,
+        isInMonth: isInMonth,
+        onTileTap: widget.onEventTap,
+        dateStringBuilder: widget.dateStringBuilder,
+        hideDayNotInMonth: hideDayNotInMonth,
+      );
+    }
     return FilledCell<T>(
       date: date,
       shouldHighlight: isToday,
@@ -516,6 +533,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
       events: events,
       onTileTap: widget.onEventTap,
       dateStringBuilder: widget.dateStringBuilder,
+      hideDayNotInMonth: hideDayNotInMonth,
     );
   }
 
@@ -607,6 +625,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
   final DatePressCallback? onDateLongPress;
   final WeekDays startDay;
   final ScrollPhysics physics;
+  final bool hideDayNotInMonth;
 
   const _MonthPageBuilder({
     Key? key,
@@ -623,6 +642,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
     required this.onDateLongPress,
     required this.startDay,
     required this.physics,
+    required this.hideDayNotInMonth,
   }) : super(key: key);
 
   @override
@@ -659,6 +679,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
                 events,
                 monthDays[index].compareWithoutTime(DateTime.now()),
                 monthDays[index].month == date.month,
+                hideDayNotInMonth,
               ),
             ),
           );

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -11,6 +11,7 @@ typedef CellBuilder<T extends Object?> = Widget Function(
   List<CalendarEventData<T>> event,
   bool isToday,
   bool isInMonth,
+  bool hideDayNotInMonth,
 );
 
 typedef EventTileBuilder<T extends Object?> = Widget Function(


### PR DESCRIPTION
# Description
Hiding and showing day which is not in month view using **hideDayNotInMonth** set true/false.
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
Fixes #328 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org