### PR TITLE
docs: Fixes CONTRIBUTING.md referencing old flutter format command 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ please read these instructions carefully.
 For a contribution to be accepted:
 
 - Follow the [Style Guide] when writing the code;
-- Format the code using `flutter format .`;
+- Format the code using `dart format .`;
 - Documentation should always be updated or added (if applicable);
 - Examples should always be updated or added (if applicable);
 - Tests should always be updated or added (if applicable) -- check the [Test writing guide] for


### PR DESCRIPTION
# Description

The command `flutter format .` has been updated as `dart format .` 
This PR updates the CONTRIBUTING.md doc to reflect this change

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org