### PR TITLE
fix: 🐛live time indicator position on timeline is not correct when st…

### DIFF
--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -35,15 +35,19 @@ class LiveTimeIndicator extends StatefulWidget {
   /// Defines height occupied by one minute.
   final double heightPerMinute;
 
+  /// First hour displayed in the layout, goes from 0 to 24
+  final int startHour;
+
   /// Widget to display tile line according to current time.
-  const LiveTimeIndicator(
-      {Key? key,
-      required this.width,
-      required this.height,
-      required this.timeLineWidth,
-      required this.liveTimeIndicatorSettings,
-      required this.heightPerMinute})
-      : super(key: key);
+  const LiveTimeIndicator({
+    Key? key,
+    required this.width,
+    required this.height,
+    required this.timeLineWidth,
+    required this.liveTimeIndicatorSettings,
+    required this.heightPerMinute,
+    required this.startHour,
+  }) : super(key: key);
 
   @override
   _LiveTimeIndicatorState createState() => _LiveTimeIndicatorState();
@@ -85,6 +89,10 @@ class _LiveTimeIndicatorState extends State<LiveTimeIndicator> {
     final timeString = widget.liveTimeIndicatorSettings.timeStringBuilder
             ?.call(DateTime.now()) ??
         '$currentHour:$currentMinute $currentPeriod';
+
+    /// remove startHour minute from [_currentTime.getTotalMinutes]
+    /// to set dy offset of live time indicator
+    final startMinutes = widget.startHour * 60;
     return CustomPaint(
       size: Size(widget.width, widget.liveTimeIndicatorSettings.height),
       painter: CurrentTimeLinePainter(
@@ -92,7 +100,8 @@ class _LiveTimeIndicatorState extends State<LiveTimeIndicator> {
         height: widget.liveTimeIndicatorSettings.height,
         offset: Offset(
           widget.timeLineWidth + widget.liveTimeIndicatorSettings.offset,
-          _currentTime.getTotalMinutes * widget.heightPerMinute,
+          (_currentTime.getTotalMinutes - startMinutes) *
+              widget.heightPerMinute,
         ),
         timeString: timeString,
         showBullet: widget.liveTimeIndicatorSettings.showBullet,

--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -264,6 +264,7 @@ class InternalDayViewPage<T extends Object?> extends StatelessWidget {
                           height: height,
                           heightPerMinute: heightPerMinute,
                           timeLineWidth: timeLineWidth,
+                          startHour: startHour,
                         ),
                       ),
                   ],

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -362,6 +362,7 @@ class InternalWeekViewPage<T extends Object?> extends StatelessWidget {
                         height: height,
                         heightPerMinute: heightPerMinute,
                         timeLineWidth: timeLineWidth,
+                        startHour: startHour,
                       ),
                   ],
                 ),


### PR DESCRIPTION
…artHour set in day and week view

- Removed/minus startHour minutes from totalMinutes of day to set dy offset of current timeline painter which set live time line indicator properly on timeline

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #346
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org


**Before :** live indicator in day view when startHour is set

![before_day_view](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/assets/122270609/47237114-bd67-4777-b297-9d06b81f634b)

**After :** live indicator in day view when startHour is set

![after_day_view_live_indicator](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/assets/122270609/4c87559c-5030-420f-8576-6abbae1c8873)

**Before :** live indicator in week view when startHour is set

![before_week_view](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/assets/122270609/8473564a-d223-4bfa-9ed0-bb8752d93d25)

**After :** live indicator in week view when startHour is set

![after_week_view_live_indicator](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/assets/122270609/b882618c-5f52-4491-8df3-d271a29759d9)
