### PR TITLE
fix: 🐛 onDateTap return wrong date when startHour is set #341

### DIFF
--- a/lib/src/components/common_components.dart
+++ b/lib/src/components/common_components.dart
@@ -133,6 +133,7 @@ class DefaultPressDetector extends StatelessWidget {
     required this.minuteSlotSize,
     this.onDateTap,
     this.onDateLongPress,
+    this.startHour = 0,
   });
 
   final DateTime date;
@@ -142,6 +143,7 @@ class DefaultPressDetector extends StatelessWidget {
   final MinuteSlotSize minuteSlotSize;
   final DateTapCallback? onDateTap;
   final DatePressCallback? onDateLongPress;
+  final int startHour;
 
   @override
   Widget build(BuildContext context) {
@@ -183,7 +185,7 @@ class DefaultPressDetector extends StatelessWidget {
         date.month,
         date.day,
         0,
-        (minuteSlotSize.minutes * slot),
+        (minuteSlotSize.minutes * slot) + (startHour * 60),
       );
 }
 

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -621,6 +621,7 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
         minuteSlotSize: minuteSlotSize,
         onDateTap: widget.onDateTap,
         onDateLongPress: widget.onDateLongPress,
+        startHour: _startHour,
       );
 
   /// Default timeline builder this builder will be used if

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -686,6 +686,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
         minuteSlotSize: minuteSlotSize,
         onDateTap: widget.onDateTap,
         onDateLongPress: widget.onDateLongPress,
+        startHour: _startHour,
       );
 
   /// Default builder for week line.


### PR DESCRIPTION
- add startHour minutes (startHour * 60) to DateTime which then passed as arguments to onDateTap

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #341 
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org