### PR TITLE
Fix: the  `_InternalDayViewPageState` is always Object #371

### DIFF
--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -176,7 +176,7 @@ class InternalDayViewPage<T extends Object?> extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<InternalDayViewPage> createState() => _InternalDayViewPageState();
+  _InternalDayViewPageState<T> createState() => _InternalDayViewPageState();
 }
 
 class _InternalDayViewPageState<T extends Object?>

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -211,7 +211,7 @@ class InternalWeekViewPage<T extends Object?> extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<InternalWeekViewPage> createState() => _InternalWeekViewPageState();
+  _InternalWeekViewPageState<T> createState() => _InternalWeekViewPageState();
 }
 
 class _InternalWeekViewPageState<T extends Object?>


### PR DESCRIPTION
# Description
Fix the problem that `_InternalDayViewPageState` is always Object.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #371 
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org