### PR TITLE
feat: Fixes issue #413: Set max width of event slot in week & day view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixes issue calendar scroll physics for day & week view. [#417](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/417)
 - Adds `onTimestampTap` callback in `WeekView`
   and `DayView`.  [#383](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/383)
+- Use `maxWidth` to set max width of event slot in day & week view. [#413](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/413)
 - `Deprecations`:
     - deprecated `backgroundColor` and `iconColor` from `CalendarPageHeader`, `DayPageHeader`, `MonthPageHeader` and `WeekPageHeader`.
         - **Solution:** use `headerStyle` instead.

--- a/example/lib/widgets/day_view_widget.dart
+++ b/example/lib/widgets/day_view_widget.dart
@@ -23,6 +23,7 @@ class DayViewWidget extends StatelessWidget {
       heightPerMinute: 3,
       timeLineBuilder: _timeLineBuilder,
       scrollPhysics: const BouncingScrollPhysics(),
+      eventArranger: SideEventArranger(maxWidth: 30),
       hourIndicatorSettings: HourIndicatorSettings(
         color: Theme.of(context).dividerColor,
       ),

--- a/example/lib/widgets/week_view_widget.dart
+++ b/example/lib/widgets/week_view_widget.dart
@@ -15,6 +15,7 @@ class WeekViewWidget extends StatelessWidget {
       key: state,
       width: width,
       showLiveTimeLineInAllDays: true,
+      eventArranger: SideEventArranger(maxWidth: 30),
       timeLineWidth: 65,
       scrollPhysics: const BouncingScrollPhysics(),
       liveTimeIndicatorSettings: LiveTimeIndicatorSettings(

--- a/lib/src/event_arrangers/side_event_arranger.dart
+++ b/lib/src/event_arrangers/side_event_arranger.dart
@@ -8,6 +8,7 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
   /// This class will provide method that will arrange
   /// all the events side by side.
   const SideEventArranger({
+    this.maxWidth,
     this.includeEdges = false,
   });
 
@@ -18,6 +19,12 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
   /// If includeEdges is true, it will offset the events else it will not.
   ///
   final bool includeEdges;
+
+  /// If enough space is available, the event slot will
+  /// use the specified max width.
+  /// Otherwise, it will reduce to fit all events in the cell.
+  /// If max width is not specified, slots will expand to fill the cell.
+  final double? maxWidth;
 
   /// {@macro event_arranger_arrange_method_doc}
   ///
@@ -100,7 +107,8 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
       final arranged = <OrganizedCalendarEventData<T>>[];
 
       for (final event in events) {
-        final slotWidth = width / event.columns;
+        final slotWidth =
+            math.min(width / event.columns, maxWidth ?? double.maxFinite);
 
         if (event.event.isNotEmpty) {
           // TODO(parth): Arrange events and add it in arranged.


### PR DESCRIPTION
# Description

 Use `maxWidth` to define the maximum width of event slot. If enough space is available, the event slot will use the specified max width. Otherwise, it will reduce to fit all events in the cell. If max width is not specified, slots will expand to fill the cell.
 

<img src="https://github.com/user-attachments/assets/848dd17a-6692-4fec-bbac-a9024468c870" width="150" height="280">
<img src="https://github.com/user-attachments/assets/c083c149-554b-457d-b0d5-d59ec3a95d36" width="150" height="280">


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #413 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org