### PR TITLE
feat: Fixes issue #385: Add `showWeekends` flag in month view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [1.4.0](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.4.0)
+- Adds `showWeekends` flag in month view to hide & show weekends view. 
+  Default is `showWeekends = true` shows all weekdays. [#385](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/385)
+- Events are now hidden for days not in the current month when hideDaysNotInMonth = true
+
 # [1.3.0 - 12 Nov 2024](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.3.0)
 
 - Fixes full day event position when fullHeaderTitle is empty.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ MonthView(
     headerBuilder: MonthHeader.hidden, // To hide month header
     showWeekTileBorder: false, // To show or hide header border
     hideDaysNotInMonth: true, // To hide days or cell that are not in current month
+    showWeekends: false, // To hide weekends default value is true
 );
 ```
 

--- a/example/lib/widgets/month_view_widget.dart
+++ b/example/lib/widgets/month_view_widget.dart
@@ -18,7 +18,10 @@ class MonthViewWidget extends StatelessWidget {
     return MonthView(
       key: state,
       width: width,
-      hideDaysNotInMonth: false,
+      showWeekends: false,
+      startDay: WeekDays.friday,
+      useAvailableVerticalSpace: true,
+      hideDaysNotInMonth: true,
       onEventTap: (event, date) {
         Navigator.of(context).push(
           MaterialPageRoute(

--- a/example/lib/widgets/week_view_widget.dart
+++ b/example/lib/widgets/week_view_widget.dart
@@ -14,6 +14,7 @@ class WeekViewWidget extends StatelessWidget {
     return WeekView(
       key: state,
       width: width,
+      showWeekends: false,
       showLiveTimeLineInAllDays: true,
       eventArranger: SideEventArranger(maxWidth: 30),
       timeLineWidth: 65,

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -514,7 +514,10 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                       itemBuilder: (_, index) {
                         final dates = DateTime(_minDate.year, _minDate.month,
                                 _minDate.day + (index * DateTime.daysPerWeek))
-                            .datesOfWeek(start: widget.startDay);
+                            .datesOfWeek(
+                          start: widget.startDay,
+                          showWeekEnds: widget.showWeekends,
+                        );
 
                         return ValueListenableBuilder(
                           valueListenable: _scrollConfiguration,


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
- Fixed if `daysNotInMonth` true hide events on hidden date.
- Added `showWeekends` flag to hide weekends. Default value is true.
- Removed empty rows if entire week dates doesn't fall in current month.
- Updated readme & change log
- Attached GIF which shows example.

<img src="https://github.com/user-attachments/assets/e972f4fc-e14d-49c6-b3ba-d9ed39aa40ca" alt="ShowWeekends flag" width="200" height="400">

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closses #385 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org