### PR TITLE
feat: add settings for WeekView days divider

### DIFF
--- a/lib/calendar_view.dart
+++ b/lib/calendar_view.dart
@@ -7,6 +7,7 @@ library calendar_view;
 export './src/calendar_constants.dart';
 export './src/calendar_controller_provider.dart';
 export './src/calendar_event_data.dart';
+export './src/weekly_event.dart';
 export './src/components/components.dart';
 export './src/day_view/day_view.dart';
 export './src/enumerations.dart';

--- a/lib/src/calendar_constants.dart
+++ b/lib/src/calendar_constants.dart
@@ -12,5 +12,5 @@ class CalendarConstants {
   static final DateTime minDate = DateTime(-271819);
 
   // fixed week start date
-  static final DateTime fixedWeekStart = DateTime(2024, 7, 1); // Monday
+  static final DateTime fixedWeekStart = DateTime(2024, 6, 30); // Monday
 }

--- a/lib/src/calendar_constants.dart
+++ b/lib/src/calendar_constants.dart
@@ -10,4 +10,7 @@ class CalendarConstants {
   static final DateTime epochDate = DateTime(1970);
   static final DateTime maxDate = DateTime(275759);
   static final DateTime minDate = DateTime(-271819);
+
+  // fixed week start date
+  static final DateTime fixedWeekStart = DateTime(2024, 7, 1); // Monday
 }

--- a/lib/src/event_controller.dart
+++ b/lib/src/event_controller.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'package:flutter/material.dart';
 
 import '../calendar_view.dart';
+import 'weekly_event.dart';
 
 class EventController<T extends Object?> extends ChangeNotifier {
   /// Calendar controller to control all the events related operations like,
@@ -121,6 +122,10 @@ class EventController<T extends Object?> extends ChangeNotifier {
   void add(CalendarEventData<T> event) {
     _calendarData.addEvent(event);
     notifyListeners();
+  }
+
+  void addWeeklyEvent(WeeklyEvent<T> weeklyEvent) {
+    add(weeklyEvent.toCalendarEvent());
   }
 
   /// Removes [event] from this controller.

--- a/lib/src/modals.dart
+++ b/lib/src/modals.dart
@@ -83,3 +83,26 @@ class LiveTimeIndicatorSettings {
         showBullet: false,
       );
 }
+
+/// Settings for the divider between the days and the WeekView grid
+class WeekDaysDividerSettings {
+  final double thickness;
+  final double height;
+  final Color color;
+  final double indent;
+  final double endIndent;
+  final bool?
+      autoIndent; // If true, the indent will be calculated automatically to match the grid instead of taking the whole width.
+
+  const WeekDaysDividerSettings({
+    this.thickness = 1,
+    this.height = 1,
+    this.color = Colors.black,
+    this.indent = 0,
+    this.endIndent = 0,
+    this.autoIndent = false,
+  })  : assert(thickness >= 0, "Thickness must be greater than or equal to 0."),
+        assert(height >= 0, "Height must be greater than or equal to 0."),
+        assert(indent >= 0, "Indent must be greater than or equal to 0."),
+        assert(endIndent >= 0, "EndIndent must be greater than or equal to 0.");
+}

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -301,14 +301,6 @@ class _InternalWeekViewPageState<T extends Object?>
           SizedBox(
             width: widget.width,
             child: Container(
-              decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(
-                    color: widget.hourIndicatorSettings.color,
-                    width: 2,
-                  ),
-                ),
-              ),
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style license
 // that can be found in the LICENSE file.
 
+// _internal_week_view_page.dart
 import 'package:flutter/material.dart';
 
 import '../components/_internal_components.dart';

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -166,6 +166,9 @@ class InternalWeekViewPage<T extends Object?> extends StatefulWidget {
   /// This method will be called when user taps on timestamp in timeline.
   final TimestampCallback? onTimestampTap;
 
+  /// Settings for the divider between the days and the WeekView grid
+  final WeekDaysDividerSettings? weekDaysDividerSettings;
+
   /// A single page for week view.
   const InternalWeekViewPage({
     Key? key,
@@ -216,6 +219,8 @@ class InternalWeekViewPage<T extends Object?> extends StatefulWidget {
     required this.weekViewScrollController,
     this.lastScrollOffset = 0.0,
     this.keepScrollOffset = false,
+    this.weekDaysDividerSettings =
+        const WeekDaysDividerSettings(height: 1, thickness: 1),
   }) : super(key: key);
 
   @override
@@ -285,8 +290,13 @@ class _InternalWeekViewPageState<T extends Object?>
             ),
           ),
           Divider(
-            thickness: 1,
-            height: 1,
+            thickness: widget.weekDaysDividerSettings?.thickness,
+            height: widget.weekDaysDividerSettings?.height,
+            color: widget.weekDaysDividerSettings?.color,
+            indent: widget.weekDaysDividerSettings?.autoIndent == true
+                ? widget.timeLineWidth + widget.hourIndicatorSettings.offset
+                : widget.weekDaysDividerSettings?.indent,
+            endIndent: widget.weekDaysDividerSettings?.endIndent,
           ),
           SizedBox(
             width: widget.width,

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -250,6 +250,9 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// Flag to keep scrollOffset of pages on page change
   final bool keepScrollOffset;
 
+  /// Settings for the divider between the days and the WeekView grid
+  final WeekDaysDividerSettings? weekDaysDividerSettings;
+
   /// Main widget for week view.
   const WeekView({
     Key? key,
@@ -310,6 +313,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
     this.fullDayHeaderTextConfig,
     this.keepScrollOffset = false,
     this.onTimestampTap,
+    this.weekDaysDividerSettings,
   })  : assert(!(onHeaderTitleTap != null && weekPageHeaderBuilder != null),
             "can't use [onHeaderTitleTap] & [weekPageHeaderBuilder] simultaneously"),
         assert((timeLineOffset) >= 0,
@@ -322,7 +326,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
             heightPerMinute > 0, "Height per minute must be greater than 0."),
         assert(
           weekDetectorBuilder == null || onDateLongPress == null,
-          """If you use [weekPressDetectorBuilder] 
+          """If you use [weekPressDetectorBuilder]
           do not provide [onDateLongPress]""",
         ),
         assert(
@@ -576,6 +580,8 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                             scrollPhysics: widget.scrollPhysics,
                             scrollListener: _scrollPageListener,
                             keepScrollOffset: widget.keepScrollOffset,
+                            weekDaysDividerSettings:
+                                widget.weekDaysDividerSettings,
                           ),
                         );
                       },

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -771,6 +771,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     if (widget.scheduleMode) {
       _minDate = CalendarConstants.fixedWeekStart;
       _maxDate = CalendarConstants.fixedWeekStart.add(Duration(days: 6));
+      _totalWeeks = 1;
     } else {
       _minDate = (widget.minDay ?? CalendarConstants.epochDate)
           .firstDayOfWeek(start: widget.startDay)

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style license
 // that can be found in the LICENSE file.
 
+// week_view.dart
 import 'package:flutter/material.dart';
 
 import '../calendar_constants.dart';
@@ -172,6 +173,15 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// saturday and sunday, only monday and tuesday will be visible in week view.
   final bool showWeekends;
 
+  /// Defines which days should be considered as weekends.
+  ///
+  /// By default Saturday and Sunday are considered as weekends.
+  /// Provide list of [WeekDays] that should be treated as weekends.
+  ///
+  /// This parameter is used in conjunction with [showWeekends] to determine
+  /// which days to display when [showWeekends] is false.
+  final List<WeekDays> weekendDays;
+
   /// Defines which days should be displayed in one week.
   ///
   /// By default all the days will be visible.
@@ -289,6 +299,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
     this.onDateLongPress,
     this.onDateTap,
     this.weekDays = WeekDays.values,
+    this.weekendDays = const [WeekDays.saturday, WeekDays.sunday],
     this.showWeekends = true,
     this.startDay = WeekDays.monday,
     this.minuteSlotSize = MinuteSlotSize.minutes60,
@@ -336,6 +347,10 @@ class WeekView<T extends Object?> extends StatefulWidget {
         assert(
           endHour <= Constants.hoursADay || endHour < startHour,
           "End hour must be less than 24 or startHour must be less than endHour",
+        ),
+        assert(
+          weekendDays.length >= 1,
+          "weekendDays must contain at least one day",
         ),
         super(key: key);
 
@@ -626,9 +641,10 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     _weekDays = widget.weekDays.toSet().toList();
 
     if (!widget.showWeekends) {
-      _weekDays
-        ..remove(WeekDays.saturday)
-        ..remove(WeekDays.sunday);
+      // Remove all weekend days from weekDays
+      _weekDays.removeWhere(
+        (day) => widget.weekendDays.contains(day),
+      );
     }
 
     assert(
@@ -636,7 +652,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
         "weekDays can not be empty.\n"
         "Make sure you are providing weekdays in initialization of "
         "WeekView. or showWeekends is true if you are providing only "
-        "saturday or sunday in weekDays.");
+        "weekend days in weekDays.");
     _totalDaysInWeek = _weekDays.length;
   }
 

--- a/lib/src/weekly_event.dart
+++ b/lib/src/weekly_event.dart
@@ -1,8 +1,9 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 import '../calendar_view.dart';
-
-final DateTime fixedWeekStart = CalendarConstants.fixedWeekStart;
+import 'constants.dart';
 
 class WeeklyEvent<T> {
   final WeekDays weekday;
@@ -19,7 +20,9 @@ class WeeklyEvent<T> {
 
   CalendarEventData<T> toCalendarEvent() {
     int daysToAdd = weekday.index - WeekDays.monday.index;
-    final date = fixedWeekStart.add(Duration(days: daysToAdd));
+    final date =
+        CalendarConstants.fixedWeekStart.add(Duration(days: daysToAdd));
+
     return CalendarEventData(
       date: date,
       startTime: DateTime(
@@ -27,11 +30,11 @@ class WeeklyEvent<T> {
       endTime: DateTime(
           date.year, date.month, date.day, endTime.hour, endTime.minute),
       event: event,
-      recurrenceSettings: RecurrenceSettings(
-        frequency: RepeatFrequency.weekly,
-        startDate: date,
-      ),
       title: '',
+      // recurrenceSettings: RecurrenceSettings(
+      //   frequency: RepeatFrequency.weekly,
+      //   startDate: date,
+      // ),
     );
   }
 }

--- a/lib/src/weekly_event.dart
+++ b/lib/src/weekly_event.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../calendar_view.dart';
+
+final DateTime fixedWeekStart = CalendarConstants.fixedWeekStart;
+
+class WeeklyEvent<T> {
+  final WeekDays weekday;
+  final TimeOfDay startTime;
+  final TimeOfDay endTime;
+  final T event;
+
+  WeeklyEvent({
+    required this.weekday,
+    required this.startTime,
+    required this.endTime,
+    required this.event,
+  });
+
+  CalendarEventData<T> toCalendarEvent() {
+    int daysToAdd = weekday.index - WeekDays.monday.index;
+    final date = fixedWeekStart.add(Duration(days: daysToAdd));
+    return CalendarEventData(
+      date: date,
+      startTime: DateTime(
+          date.year, date.month, date.day, startTime.hour, startTime.minute),
+      endTime: DateTime(
+          date.year, date.month, date.day, endTime.hour, endTime.minute),
+      event: event,
+      recurrenceSettings: RecurrenceSettings(
+        frequency: RepeatFrequency.weekly,
+        startDate: date,
+      ),
+      title: '',
+    );
+  }
+}


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

In WeekView, the styling for the Divider between the week days and the week view grid is hard coded (like shown in the screenshot below):
![image](https://github.com/user-attachments/assets/0016a4ce-e863-4383-8370-49229b2cd5e5)

So this PR adds a new class `WeekDaysDividerSettings` to control the styling for that divider, also includes a `autoIndent` parameter to prevent the divider from taking the entire width and indenting it to start from where the days row starts.

Result with autoIndent set to true (with some styles applied through the new settings):
![image](https://github.com/user-attachments/assets/184427e6-1866-478a-899f-28456c6de88e)

Same result with autoIndent set to false:
![image](https://github.com/user-attachments/assets/4aa7a38f-042d-4934-9e39-7e81ba928605)


This PR also removes the useless hardcoded border below the week days:
Before (autoIndent set to True):
![image](https://github.com/user-attachments/assets/3e2a5258-7e5a-4673-9f47-70814a89a7bf)

After:
![image](https://github.com/user-attachments/assets/184427e6-1866-478a-899f-28456c6de88e)

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #374 and #430 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org