### PR TITLE
fix: Fixes issue #435: 🐛 Fix tap issue for days not in month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixes right icon always shows default icon in `CalendarPageHeader` when providing custom icon. [#432](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/432)
 - Adds `hideDaysNotInMonth` argument in `cellBuilder` in readme. [#433](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/433)
 - Fixes `titleColor` of date for `hideDaysNotInMonth: false`.
+- Fixes tap `onTileDoubleTap` & `onTileLongTap` issue for `hideDaysNotInMonth` in month view. [#435](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/435)
 
 # [1.3.0 - 12 Nov 2024](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.3.0)
 

--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -570,6 +570,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
         events: events,
         isInMonth: isInMonth,
         onTileTap: widget.onEventTap,
+        onTileDoubleTap: widget.onEventDoubleTap,
+        onTileLongTap: widget.onEventLongTap,
         dateStringBuilder: widget.dateStringBuilder,
         hideDaysNotInMonth: hideDaysNotInMonth,
       );


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

- Fixed tap issue: If  `hideDaysNotInMonth`: true in month view then in default filled cell `onTileDoubleTap` & `onTileLongTap` is not working.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Related issue: #435 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org