### PR TITLE
fix: #446 Weekview does reflect changes to startHour and endHour.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,17 +255,18 @@ assigned.
 
 Methods provided by `EventController`
 
-| Name            | Parameters                                                   | Description                                               |
-|-----------------|--------------------------------------------------------------|-----------------------------------------------------------|
-| add             | CalendarEventData\<T\> event                                 | Adds one event in controller and rebuilds view.           |
-| addAll          | List\<CalendarEventData\<T\>\> events                        | Adds list of events in controller and rebuilds view.      |
-| remove          | CalendarEventData\<T\> event                                 | Removes an event from controller and rebuilds view.       |
-| removeAll       | List\<CalendarEventData\<T\>\> events                        | Removes all event defined in the list                     |
-| removeWhere     | TestPredicate\<CalendarEventData\<T\>\> test                 | Removes all events for which test returns true.           |
-| update          | CalendarEventData\<T\> event, CalendarEventData\<T\> updated | Updates event with updated event.                         |
-| getFullDayEvent | DateTime date                                                | Returns the list of full day events stored in controller  |
-| updateFilter    | EventFilter\<T\> newFilter                                   | Updates the event filter of the controller.               |
-| getEventsOnDay  | DateTime date                                                | Returns list of events on `date`                          |
+| Name            | Parameters                                                   | Description                                                 |
+|-----------------|--------------------------------------------------------------|-------------------------------------------------------------|
+| add             | CalendarEventData\<T\> event                                 | Adds one event in controller and rebuilds view.             |
+| addAll          | List\<CalendarEventData\<T\>\> events                        | Adds list of events in controller and rebuilds view.        |
+| remove          | CalendarEventData\<T\> event                                 | Removes an event from controller and rebuilds view.         |
+| removeAll       | List\<CalendarEventData\<T\>\> events                        | Removes all event defined in the list and rebuilds the view |
+| clear           |                                                              | Removes events from the controller and rebuilds the view    |
+| removeWhere     | TestPredicate\<CalendarEventData\<T\>\> test                 | Removes all events for which test returns true.             |
+| update          | CalendarEventData\<T\> event, CalendarEventData\<T\> updated | Updates event with updated event.                           |
+| getFullDayEvent | DateTime date                                                | Returns the list of full day events stored in controller    |
+| updateFilter    | EventFilter\<T\> newFilter                                   | Updates the event filter of the controller.                 |
+| getEventsOnDay  | DateTime date                                                | Returns list of events on `date`                            |
 
 Check [documentation](https://pub.dev/documentation/calendar_view/latest/calendar_view/EventController-class.html) for more info.
 

--- a/lib/src/event_controller.dart
+++ b/lib/src/event_controller.dart
@@ -113,6 +113,12 @@ class EventController<T extends Object?> extends ChangeNotifier {
     notifyListeners();
   }
 
+  void clear() {
+    _calendarData.clear();
+
+    notifyListeners();
+  }
+
   /// Removes multiple [event] from this controller.
   void removeWhere(TestPredicate<CalendarEventData<T>> test) {
     _calendarData.removeWhere(test);
@@ -343,6 +349,14 @@ class CalendarData<T extends Object?> {
       }
     }
     return events;
+  }
+
+  /// Remove all events from the controller.
+  void clear() {
+    _fullDayEventList.clear();
+    _rangingEventList.clear();
+    _singleDayEvents.clear();
+    _eventList.clear();
   }
   //#endregion
 }

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -227,6 +227,9 @@ class _InternalWeekViewPageState<T extends Object?>
     extends State<InternalWeekViewPage<T>> {
   late ScrollController scrollController;
 
+  late int startHour;
+  late int endHour;
+
   @override
   void initState() {
     super.initState();
@@ -234,6 +237,9 @@ class _InternalWeekViewPageState<T extends Object?>
       initialScrollOffset: widget.lastScrollOffset,
     );
     scrollController.addListener(_scrollControllerListener);
+
+    startHour = widget.startHour;
+    endHour = widget.endHour;
   }
 
   @override
@@ -246,6 +252,13 @@ class _InternalWeekViewPageState<T extends Object?>
 
   void _scrollControllerListener() {
     widget.scrollListener(scrollController);
+  }
+
+  @override
+  void didUpdateWidget(InternalWeekViewPage<T> oldWidget) {
+    startHour = widget.startHour;
+    endHour = widget.endHour;
+    super.didUpdateWidget(oldWidget);
   }
 
   @override
@@ -368,8 +381,8 @@ class _InternalWeekViewPageState<T extends Object?>
                         dashSpaceWidth:
                             widget.hourIndicatorSettings.dashSpaceWidth,
                         emulateVerticalOffsetBy: widget.emulateVerticalOffsetBy,
-                        startHour: widget.startHour,
-                        endHour: widget.endHour,
+                        startHour: startHour,
+                        endHour: endHour,
                       ),
                     ),
                     if (widget.showHalfHours)
@@ -451,13 +464,13 @@ class _InternalWeekViewPageState<T extends Object?>
                                       eventTileBuilder: widget.eventTileBuilder,
                                       scrollNotifier:
                                           widget.scrollConfiguration,
-                                      startHour: widget.startHour,
+                                      startHour: startHour,
                                       events: widget.controller.getEventsOnDay(
                                         filteredDates[index],
                                         includeFullDayEvents: false,
                                       ),
                                       heightPerMinute: widget.heightPerMinute,
-                                      endHour: widget.endHour,
+                                      endHour: endHour,
                                     ),
                                   ],
                                 ),
@@ -473,7 +486,7 @@ class _InternalWeekViewPageState<T extends Object?>
                       height: widget.height,
                       timeLineOffset: widget.timeLineOffset,
                       timeLineBuilder: widget.timeLineBuilder,
-                      startHour: widget.startHour,
+                      startHour: startHour,
                       showHalfHours: widget.showHalfHours,
                       showQuarterHours: widget.showQuarterHours,
                       liveTimeIndicatorSettings:
@@ -490,7 +503,7 @@ class _InternalWeekViewPageState<T extends Object?>
                         height: widget.height,
                         heightPerMinute: widget.heightPerMinute,
                         timeLineWidth: widget.timeLineWidth,
-                        startHour: widget.startHour,
+                        startHour: startHour,
                         endHour: widget.endHour,
                       ),
                   ],

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -469,6 +469,9 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
 
     _eventArranger = widget.eventArranger ?? SideEventArranger<T>();
 
+    _startHour = widget.startHour;
+    _endHour = widget.endHour;
+
     // Update heights.
     _calculateHeights();
 

--- a/test/src/event_controller_test.dart
+++ b/test/src/event_controller_test.dart
@@ -1,0 +1,25 @@
+import 'package:calendar_view/calendar_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('event controller ...', (tester) async {
+    final controller = EventController();
+
+    final now = DateTime.now();
+    controller.add(CalendarEventData<String>(
+        title: 'none',
+        date: now,
+        startTime: now,
+        endTime: now.add(Duration(hours: 1))));
+    controller.add(CalendarEventData<String>(
+      title: 'All Day',
+      date: DateTime.now().withoutTime,
+    ));
+
+    expect(controller.getFullDayEvent(now).length, equals(1));
+    expect(controller.getEventsOnDay(now).length, equals(2));
+    expect(controller.allEvents.length, equals(2));
+    controller.clear();
+    expect(controller.allEvents.length, equals(0));
+  });
+}


### PR DESCRIPTION
# Description
The week view doesn't reflect changes to startHour or endHour when it rebuilds.

Move move both of these values into the InternalWeekView state and update the state when the widget changes.

## Checklist

- [ x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ x] I have followed the [Contributor Guide] when preparing my PR.
- [ x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

None

### Migration instructions

Not required.

- [ ] Yes, this PR is a breaking change.
- [x ] No, this PR is not a breaking change.


## Related Issues
Closes #446


<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org