### PR TITLE
fix : 🐛 Fixed Splash issue on timeline in `WeekView` and `DayView` when `onTimestampTap` is null.(#459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Adds `onEventTapDetails`, `onEventDoubleTapDetails` & `onEventLongTapDetails` gesture recognizers to get tap details. [#390](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/390)
 - Fixed `onEventTap` in `MonthView` to ignore when it is
   null. [#278](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/278)
+- Fixed Splash issue on timeline in `WeekView` and `DayView` when `onTimestampTap` is
+  null. [#459](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/459)
 
 # [1.4.0 - 7 Jan 2025](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/1.4.0)
 

--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -313,11 +313,7 @@ class _TimeLineState extends State<TimeLine> {
           height: widget.hourHeight,
           width: widget.timeLineWidth,
           child: InkWell(
-            onTap: () {
-              if (widget.onTimestampTap != null) {
-                widget.onTimestampTap!(dateTime);
-              }
-            },
+            onTap: widget.onTimestampTap.safeVoidCall(dateTime),
             child: widget.timeLineBuilder.call(dateTime),
           ),
         ),


### PR DESCRIPTION

# Description
Fixed Splash issue on timeline in `WeekView` and `DayView` when `onTimestampTap` is null
- Updated login on the tap of the inkwell so now it will work as expected.
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #459 
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org