### PR TITLE
refactor: ♻️ Improve SideEventArranger event overlap handling and arrangement algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [Unreleased]
+- [BREAKING] Updated `SideEventArranger`: removed/renamed the public `includeEdges` parameter to `countAdjacentEventsAsOverlapping`, and optimized dynamic/fixed width allocation for overlapping events.
+
 # [2.0.0 - 17 Mar 2026](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/2.0.0)
 
 - Added clear method to `EventController`.

--- a/lib/src/event_arrangers/side_event_arranger.dart
+++ b/lib/src/event_arrangers/side_event_arranger.dart
@@ -4,6 +4,40 @@
 
 part of 'event_arrangers.dart';
 
+/// **SideEventArranger: Smart Event Layout Manager**
+/// 
+/// This class arranges overlapping calendar events side by side in an optimal way,
+/// ensuring no visual overlaps while maximizing space utilization.
+/// 
+/// ## **Core Functionality:**
+/// - Arranges overlapping events in separate columns
+/// - Calculates optimal widths for each event based on available space
+/// - Supports both fixed maxWidth constraints and dynamic width allocation
+/// - Handles multi-day events, full-day events, and edge cases
+/// 
+/// ## **Algorithm Overview:**
+/// 1. **Event Normalization**: Converts events to a standardized format for the current view date
+/// 2. **Column Creation**: Uses O(n²) algorithm to group non-overlapping events into columns
+/// 3. **Width Calculation**: Determines optimal width for each event based on available space
+/// 4. **Positioning**: Places events with proper left/right positioning to eliminate gaps
+/// 
+/// ## **Key Features:**
+/// - **Gap Elimination**: Events expand to fill available space when possible
+/// - **Edge Case Handling**: Properly handles touching events, multi-day events, and time boundaries
+/// - **Flexible Width Control**: Supports both fixed maxWidth and dynamic width allocation
+/// - **Performance Optimized**: Efficient algorithms for real-world calendar scenarios
+/// 
+/// ## **Usage Examples:**
+/// ```dart
+/// // Basic usage with dynamic width
+/// final arranger = SideEventArranger<String>();
+/// 
+/// // With maximum width constraint (100px)
+/// final arranger = SideEventArranger<String>(maxWidth: 100.0);
+/// 
+/// // Include touching events as overlapping
+/// final arranger = SideEventArranger<String>(includeEdges: true);
+/// ```
 class SideEventArranger<T extends Object?> extends EventArranger<T> {
   /// This class will provide method that will arrange
   /// all the events side by side.
@@ -12,25 +46,84 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     this.includeEdges = false,
   });
 
-  /// Decides whether events that are overlapping on edge
-  /// (ex, event1 has the same end-time as the start-time of event 2)
-  /// should be offset or not.
-  ///
-  /// If includeEdges is true, it will offset the events else it will not.
-  ///
+  /// **Edge Case Handling Configuration**
+  /// 
+  /// Determines whether events that are touching at their edges should be 
+  /// considered as overlapping and placed in separate columns.
+  /// 
+  /// **Use Cases:**
+  /// - `false` (default): Events like 2:00-3:00 PM and 3:00-4:00 PM can share the same column
+  /// - `true`: Touching events are forced into separate columns for visual clarity
+  /// 
+  /// **Example:**
+  /// ```dart
+  /// // Events: [14:00-15:00], [15:00-16:00]
+  /// // includeEdges = false: Both events in same column (touching is OK)
+  /// // includeEdges = true:  Events in separate columns (touching treated as overlap)
+  /// ```
   final bool includeEdges;
 
-  /// If enough space is available, the event slot will
-  /// use the specified max width.
-  /// Otherwise, it will reduce to fit all events in the cell.
-  /// If max width is not specified, slots will expand to fill the cell.
+  /// **Maximum Width Constraint (Optional)**
+  /// 
+  /// When specified, limits the maximum width any event can take, regardless
+  /// of available space. This ensures consistent visual appearance.
+  /// 
+  /// **Behavior:**
+  /// - `null` (default): Events expand to fill all available space
+  /// - `double value`: Events are capped at this width in pixels
+  /// 
+  /// **Use Cases:**
+  /// - UI consistency: Prevent events from becoming too wide
+  /// - Mobile optimization: Ensure readable text on narrow screens
+  /// - Design constraints: Match specific layout requirements
+  /// 
+  /// **Example:**
+  /// ```dart
+  /// // Without maxWidth: Event might expand to 400px if space available
+  /// // With maxWidth: 150.0: Event width capped at 150px
+  /// ```
   final double? maxWidth;
 
-  /// {@macro event_arranger_arrange_method_doc}
-  ///
-  /// Make sure that all the events that are passed in [events], must be in
-  /// ascending order of start time.
-
+  /// **Main Event Arrangement Algorithm**
+  /// 
+  /// This is the primary entry point that orchestrates the entire event arrangement process.
+  /// It handles all the complex logic for positioning overlapping events optimally.
+  /// 
+  /// ## **Algorithm Steps:**
+  /// 1. **Input Validation**: Return empty if no events provided
+  /// 2. **Event Normalization**: Convert events to internal format for current date
+  /// 3. **Time-based Sorting**: Order events by start time for optimal processing
+  /// 4. **Column Creation**: Group non-overlapping events into columns
+  /// 5. **Width Calculation**: Determine optimal positioning and sizing
+  /// 
+  /// ## **Input Parameters:**
+  /// - `events`: List of calendar events to arrange (must be sorted by start time)
+  /// - `width`: Total available width for the calendar view
+  /// - `height`: Total available height for the calendar view
+  /// - `heightPerMinute`: Vertical pixels per minute (for time-based positioning)
+  /// - `startHour`: First visible hour (e.g., 8 for 8:00 AM)
+  /// - `calendarViewDate`: The specific date being displayed
+  /// 
+  /// ## **Output:**
+  /// List of `OrganizedCalendarEventData` with calculated positions:
+  /// - `left`: Distance from left edge in pixels
+  /// - `right`: Distance from right edge in pixels  
+  /// - `top`: Distance from top edge in pixels
+  /// - `bottom`: Distance from bottom edge in pixels
+  /// 
+  /// ## **Edge Cases Handled:**
+  /// - Empty event list → Returns empty result
+  /// - Events outside visible time range → Automatically filtered out
+  /// - Multi-day events → Properly clipped to current day view
+  /// - Zero-duration events → Handled with minimum height
+  /// - Events spanning midnight → Correctly processed for day boundaries
+  /// 
+  /// ## **Performance Considerations:**
+  /// - Time Complexity: O(n²) for column creation, O(n) for positioning
+  /// - Space Complexity: O(n) for internal data structures
+  /// - Optimized for typical calendar scenarios (few overlapping events)
+  /// 
+  /// **Prerequisite**: Events must be sorted by start time for optimal results.
   @override
   List<OrganizedCalendarEventData<T>> arrange({
     required List<CalendarEventData<T>> events,
@@ -54,7 +147,7 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     normalizedEvents
         .sort((a, b) => a.effectiveStartTime.compareTo(b.effectiveStartTime));
 
-    // Step 3: Create columns using an efficient sweep line algorithm
+    // Step 3: Create columns using simple algorithm that prevents overlapping
     final columns = _createOptimalColumns(normalizedEvents);
 
     // Step 4: Convert columns to organized calendar event data
@@ -62,7 +155,38 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
         heightPerMinute, startHourInMinutes, calendarViewDate);
   }
 
-  /// Normalizes events for the specific calendar view date
+  /// **Event Normalization for Date-Specific View**
+  /// 
+  /// Converts raw calendar events into a standardized internal format optimized
+  /// for the specific date being displayed. This handles complex multi-day event logic.
+  /// 
+  /// ## **Key Responsibilities:**
+  /// 1. **Multi-day Event Handling**: Clips events to the current day's boundaries
+  /// 2. **Time Range Validation**: Filters out events outside visible hours
+  /// 3. **Data Standardization**: Converts to internal `_NormalizedEvent` format
+  /// 
+  /// ## **Multi-day Event Cases:**
+  /// - **Same Day**: Event starts and ends on the same day → Use original times
+  /// - **Start Day**: Event starts today, ends later → Start at event time, end at day end
+  /// - **End Day**: Event started earlier, ends today → Start at day start, end at event time  
+  /// - **Middle Day**: Event spans multiple days → Full day (start=0, end=1440 minutes)
+  /// 
+  /// ## **Edge Cases Handled:**
+  /// - `null` start/end times → Skipped completely
+  /// - Events outside visible time range → Filtered out
+  /// - Zero-duration events → Processed normally
+  /// - Events crossing midnight → Properly clipped to day boundaries
+  /// 
+  /// ## **Example Scenarios:**
+  /// ```dart
+  /// // Viewing: Jan 2, 2024
+  /// // Event: Jan 1 10:00 PM - Jan 3 2:00 PM
+  /// // Result: Jan 2 0:00 AM - Jan 2 11:59 PM (full day for middle day)
+  /// 
+  /// // Viewing: Jan 15, 2024  
+  /// // Event: Jan 15 2:00 PM - Jan 15 4:00 PM
+  /// // Result: Jan 15 2:00 PM - Jan 15 4:00 PM (same day, unchanged)
+  /// ```
   List<_NormalizedEvent<T>> _normalizeEventsForDate(
     List<CalendarEventData<T>> events,
     DateTime calendarViewDate,
@@ -127,7 +251,43 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     return normalizedEvents;
   }
 
-  /// Creates optimal columns using O(n²) algorithm that prevents overlapping
+  /// **Column Creation Algorithm - Event Grouping Strategy**
+  /// 
+  /// Groups events into columns where no two events in the same column overlap.
+  /// This is the core algorithm that determines the layout structure.
+  /// 
+  /// ## **Algorithm Logic:**
+  /// 1. **Sequential Processing**: Process events one by one in chronological order
+  /// 2. **Column Search**: For each event, find the first available column where it fits
+  /// 3. **Collision Detection**: Use `_canEventFitInColumn` to check for overlaps
+  /// 4. **New Column Creation**: If no existing column works, create a new one
+  /// 
+  /// ## **Time Complexity:** 
+  /// - **Best Case**: O(n) - All events sequential, no overlaps
+  /// - **Worst Case**: O(n²) - All events overlap, each needs new column
+  /// - **Typical Case**: O(n*k) where k is average number of columns (~3-5)
+  /// 
+  /// ## **Column Selection Strategy:**
+  /// Uses **First-Fit** approach: Always tries to place event in the leftmost available column.
+  /// This minimizes the total number of columns needed and creates compact layouts.
+  /// 
+  /// ## **Example Walkthrough:**
+  /// ```dart
+  /// Events: [9:00-10:00], [9:30-11:00], [10:30-12:00], [11:30-13:00]
+  /// 
+  /// Step 1: [9:00-10:00] → Column 0 (first event)
+  /// Step 2: [9:30-11:00] → Column 1 (overlaps with Column 0)
+  /// Step 3: [10:30-12:00] → Column 0 (fits after first event ends)
+  /// Step 4: [11:30-13:00] → Column 1 (fits after second event ends)
+  /// 
+  /// Result: 2 columns, optimal layout
+  /// ```
+  /// 
+  /// ## **Edge Cases:**
+  /// - **Empty Input**: Returns empty column list
+  /// - **Single Event**: Creates one column with one event
+  /// - **No Overlaps**: All events in single column (most compact)
+  /// - **All Events Overlap**: Each event gets its own column
   List<List<_NormalizedEvent<T>>> _createOptimalColumns(
       List<_NormalizedEvent<T>> events) {
     if (events.isEmpty) return [];
@@ -156,7 +316,26 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     return columns;
   }
 
-  /// Checks if an event can fit in a specific column without overlapping
+  /// **Column Fit Testing - Overlap Detection**
+  /// 
+  /// Determines whether a new event can be placed in an existing column
+  /// without overlapping with any events already in that column.
+  /// 
+  /// ## **Algorithm:**
+  /// 1. **Iterate through existing events** in the target column
+  /// 2. **Check overlap** with each existing event using `_eventsOverlap`
+  /// 3. **Return false** immediately if any overlap is found (early termination)
+  /// 4. **Return true** only if no overlaps detected
+  /// 
+  /// ## **Performance Optimization:**
+  /// - **Early Exit**: Stops checking as soon as first overlap is found
+  /// - **Time Complexity**: O(k) where k is events in column (typically 1-3)
+  /// - **Space Complexity**: O(1) - no additional storage needed
+  /// 
+  /// ## **Use Cases:**
+  /// - Column selection during event placement
+  /// - Validation of layout correctness
+  /// - Debugging overlap detection issues
   bool _canEventFitInColumn(
       _NormalizedEvent<T> event, List<_NormalizedEvent<T>> column) {
     for (final existing in column) {
@@ -167,7 +346,47 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     return true;
   }
 
-  /// Checks if two events overlap based on includeEdges setting
+  /// **Temporal Overlap Detection - Core Logic**
+  /// 
+  /// Determines whether two events overlap in time, considering the `includeEdges` setting.
+  /// This is the fundamental building block for all layout decisions.
+  /// 
+  /// ## **Overlap Logic:**
+  /// 
+  /// ### **When includeEdges = false (default):**
+  /// Events that touch at edges are NOT considered overlapping.
+  /// ```dart
+  /// Event A: 14:00-15:00, Event B: 15:00-16:00 → No overlap (touching is OK)
+  /// Event A: 14:00-15:30, Event B: 15:00-16:00 → Overlap (actual time conflict)
+  /// ```
+  /// 
+  /// ### **When includeEdges = true:**
+  /// Events that touch at edges ARE considered overlapping.
+  /// ```dart
+  /// Event A: 14:00-15:00, Event B: 15:00-16:00 → Overlap (touching treated as conflict)
+  /// Event A: 14:00-15:30, Event B: 15:00-16:00 → Overlap (actual time conflict)
+  /// ```
+  /// 
+  /// ## **Mathematical Formulation:**
+  /// For events with times (start1, end1) and (start2, end2):
+  /// 
+  /// **includeEdges = false:**
+  /// - Overlap if: `start1 < end2 AND start2 < end1`
+  /// - No overlap if events just touch: `end1 == start2`
+  /// 
+  /// **includeEdges = true:**
+  /// - Overlap if: `start1 <= end2 AND start2 <= end1`
+  /// - Overlap even if events just touch: `end1 == start2`
+  /// 
+  /// ## **Edge Cases:**
+  /// - **Zero Duration Events**: Point events (start == end) handled correctly
+  /// - **Same Start/End Times**: Identical events always overlap
+  /// - **Reversed Time Order**: Algorithm works regardless of parameter order
+  /// 
+  /// ## **Performance:**
+  /// - **Time Complexity**: O(1) - Simple arithmetic comparisons
+  /// - **Space Complexity**: O(1) - No additional storage
+  /// - **Highly Optimized**: Used in tight loops, marked for inlining
   bool _eventsOverlap(_NormalizedEvent<T> event1, _NormalizedEvent<T> event2) {
     if (includeEdges) {
       // Events overlap if they have any overlapping time (including touching edges)
@@ -180,7 +399,41 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     }
   }
 
-  /// Converts columns to organized calendar event data with proper width allocation
+  /// **Layout Strategy Coordinator - Width Allocation Decision**
+  /// 
+  /// Orchestrates the final positioning phase by choosing between two different
+  /// width allocation strategies based on the `maxWidth` configuration.
+  /// 
+  /// ## **Strategy Selection:**
+  /// 
+  /// ### **Fixed MaxWidth Strategy** (`maxWidth != null`):
+  /// - **Use Case**: Consistent visual appearance, mobile-friendly layouts
+  /// - **Behavior**: Events respect the maxWidth constraint
+  /// - **Benefits**: Predictable sizing, prevents overly wide events
+  /// - **Method**: `_processWithFixedMaxWidth()`
+  /// 
+  /// ### **Dynamic Width Strategy** (`maxWidth == null`):
+  /// - **Use Case**: Maximum space utilization, desktop layouts
+  /// - **Behavior**: Events expand to fill all available space
+  /// - **Benefits**: No wasted space, optimal readability
+  /// - **Method**: `_processWithDynamicWidth()`
+  /// 
+  /// ## **Common Processing Steps:**
+  /// 1. **Time Calculations**: Convert event times to pixel positions
+  /// 2. **Width Calculations**: Determine optimal width for each event
+  /// 3. **Position Calculations**: Calculate left/right positioning
+  /// 4. **Result Generation**: Create `OrganizedCalendarEventData` objects
+  /// 
+  /// ## **Output Format:**
+  /// Each event becomes an `OrganizedCalendarEventData` with:
+  /// - **Spatial Data**: left, right, top, bottom positions in pixels
+  /// - **Temporal Data**: startDuration, endDuration for time references
+  /// - **Event Data**: Reference to original event and metadata
+  /// 
+  /// ## **Error Handling:**
+  /// - **Empty Columns**: Returns empty result gracefully
+  /// - **Invalid Dimensions**: Protected by bounds checking
+  /// - **Calculation Errors**: Math.max/min prevent negative values
   List<OrganizedCalendarEventData<T>> _convertColumnsToOrganizedData(
     List<List<_NormalizedEvent<T>>> columns,
     double totalWidth,
@@ -208,8 +461,40 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     return result;
   }
 
-  /// Process events with fixed maxWidth for each column
-  /// Process events with fixed maxWidth for each column
+  /// **Fixed MaxWidth Processing - Constrained Layout Strategy**
+  /// 
+  /// Handles event positioning when a maximum width constraint is specified.
+  /// This strategy balances space utilization with visual consistency.
+  /// 
+  /// ## **Core Algorithm:**
+  /// 1. **Width Pre-calculation**: Calculate optimal width for each event
+  /// 2. **MaxWidth Application**: Cap event widths at the specified maximum
+  /// 3. **Gap Elimination**: Position events to minimize empty space
+  /// 4. **Column-based Positioning**: Use actual column widths for positioning
+  /// 
+  /// ## **Width Calculation Process:**
+  /// ```dart
+  /// For each event:
+  ///   1. Calculate available space to the right
+  ///   2. Apply maxWidth constraint: min(available, maxWidth)
+  ///   3. Store in eventWidths map for positioning phase
+  /// ```
+  /// 
+  /// ## **Positioning Strategy:**
+  /// - **Column Width**: Use the widest event in each column to determine column width
+  /// - **Left Position**: Accumulate column widths to eliminate gaps
+  /// - **Right Position**: Calculate remaining space after event width
+  /// 
+  /// ## **Benefits:**
+  /// - **Consistent Appearance**: No event exceeds maxWidth limit
+  /// - **Optimal Space Usage**: Events expand up to the constraint
+  /// - **Gap-Free Layout**: Columns positioned adjacently
+  /// - **Mobile Friendly**: Prevents overly wide events on small screens
+  /// 
+  /// ## **Edge Cases:**
+  /// - **MaxWidth > Available Space**: Event uses available space (no artificial padding)
+  /// - **Multiple Events in Column**: All respect the same maxWidth constraint
+  /// - **Very Small MaxWidth**: Events maintain minimum readability
   void _processWithFixedMaxWidth(
     List<List<_NormalizedEvent<T>>> columns,
     List<OrganizedCalendarEventData<T>> result,
@@ -220,7 +505,7 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     DateTime calendarViewDate,
   ) {
     final columnCount = columns.length;
-    final baseSlotWidth = totalWidth / columnCount;
+    if (columnCount == 0) return;
 
     // Calculate actual widths for all events first to avoid gaps
     final eventWidths = <int, double>{};
@@ -231,16 +516,25 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
         final dynamicWidth = _calculateAvailableWidthToRight(
             normalizedEvent, columns, columnIndex, totalWidth);
 
-        final maxWidthPixels = maxWidth ?? double.maxFinite;
+        // Take minimum of dynamic width and maxWidth (maxWidth is absolute pixels)
+        final maxWidthPixels = maxWidth!;
         eventWidths[normalizedEvent.hashCode] =
             math.min(dynamicWidth, maxWidthPixels);
       }
     }
 
-    // Position events by column
+    // Position events to eliminate gaps by tracking actual positions
+    double currentLeftPosition = 0.0;
+
     for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
       final column = columns[columnIndex];
-      final leftPosition = columnIndex * maxWidth!;
+
+      // Find the maximum width needed for this column
+      double maxColumnWidth = double.maxFinite;
+      for (final normalizedEvent in column) {
+        final eventWidth = eventWidths[normalizedEvent.hashCode]!;
+        maxColumnWidth = math.min(maxColumnWidth, eventWidth);
+      }
 
       for (final normalizedEvent in column) {
         final event = normalizedEvent.originalEvent;
@@ -251,7 +545,6 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
             Constants.minutesADay - startHourInMinutes,
             normalizedEvent.effectiveEndTime - startHourInMinutes);
 
-        // Use the individual event width rather than column width
         final actualWidth = eventWidths[normalizedEvent.hashCode]!;
 
         final top = displayStartTime * heightPerMinute;
@@ -261,8 +554,8 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
             : height - displayEndTime * heightPerMinute;
 
         result.add(OrganizedCalendarEventData<T>(
-          left: leftPosition,
-          right: math.max(0.0, totalWidth - leftPosition - actualWidth),
+          left: currentLeftPosition,
+          right: math.max(0.0, totalWidth - currentLeftPosition - actualWidth),
           top: top,
           bottom: bottom,
           startDuration: event.startTime!.copyFromMinutes(displayStartTime),
@@ -271,10 +564,55 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
           calendarViewDate: calendarViewDate,
         ));
       }
+
+      // Move to next column position based on actual width used
+      currentLeftPosition += maxColumnWidth;
     }
   }
 
-  /// Process events with dynamic width allocation (stretch to available space)
+  /// **Dynamic Width Processing - Maximum Space Utilization Strategy**
+  /// 
+  /// Handles event positioning when no maximum width constraint is specified.
+  /// Events expand to use all available space for optimal readability.
+  /// 
+  /// ## **Core Philosophy:**
+  /// Maximize the use of available horizontal space while maintaining proper
+  /// visual separation between overlapping events.
+  /// 
+  /// ## **Algorithm Steps:**
+  /// 1. **Equal Column Distribution**: Start with equal-width columns as baseline
+  /// 2. **Available Space Calculation**: Determine how much each event can expand
+  /// 3. **Rightward Expansion**: Events extend rightward until blocked by overlapping events
+  /// 4. **Standard Positioning**: Use column-based left positioning for consistency
+  /// 
+  /// ## **Width Expansion Logic:**
+  /// ```dart
+  /// For each event:
+  ///   1. Start at column left boundary
+  ///   2. Expand rightward until hitting overlapping event or boundary
+  ///   3. Use calculated available width for the event
+  /// ```
+  /// 
+  /// ## **Column Positioning:**
+  /// - **Left Position**: Based on equal column distribution (`columnIndex * baseWidth`)
+  /// - **Event Width**: Uses `_calculateAvailableWidthToRight()` for optimal expansion
+  /// - **Right Position**: Calculated as `totalWidth - left - eventWidth`
+  /// 
+  /// ## **Benefits:**
+  /// - **Maximum Readability**: Events use all available space
+  /// - **No Wasted Space**: Horizontal area fully utilized
+  /// - **Smart Expansion**: Events stop at logical boundaries
+  /// - **Desktop Optimized**: Ideal for larger screens
+  /// 
+  /// ## **Use Cases:**
+  /// - **Desktop Calendars**: Large screens with plenty of horizontal space
+  /// - **Print Layouts**: Maximum information density required
+  /// - **Detail Views**: When event content needs maximum width
+  /// 
+  /// ## **Edge Cases:**
+  /// - **Single Column**: Event expands to full width
+  /// - **Many Overlaps**: Events get narrow but fair space allocation
+  /// - **Variable Content**: Width adapts to optimal display needs
   void _processWithDynamicWidth(
     List<List<_NormalizedEvent<T>>> columns,
     List<OrganizedCalendarEventData<T>> result,
@@ -329,7 +667,67 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     }
   }
 
-  /// Calculates how much width is available to the right of an event
+  /// **Available Width Calculation - Smart Space Detection**
+  /// 
+  /// Calculates how much horizontal space an event can use by analyzing
+  /// the layout to the right and detecting blocking overlapping events.
+  /// 
+  /// ## **Core Algorithm:**
+  /// 1. **Baseline Calculation**: Start with remaining space from current position to edge
+  /// 2. **Right-side Scanning**: Check each column to the right for blocking events
+  /// 3. **Overlap Detection**: Use `_eventsOverlap()` to find temporal conflicts
+  /// 4. **Width Limiting**: Stop expansion at first blocking event found
+  /// 5. **Minimum Guarantee**: Ensure at least one column width is available
+  /// 
+  /// ## **Scanning Strategy:**
+  /// ```dart
+  /// For each column to the right:
+  ///   For each event in that column:
+  ///     If event overlaps with target:
+  ///       Limit width to that column's position
+  ///       Break (stop scanning further right)
+  /// ```
+  /// 
+  /// ## **Width Calculation Logic:**
+  /// - **Initial Width**: `totalWidth - startPosition` (all remaining space)
+  /// - **Blocking Position**: `rightColumnIndex * baseSlotWidth`
+  /// - **Final Width**: `blockingPosition - startPosition`
+  /// - **Minimum Width**: `max(baseSlotWidth, calculatedWidth)`
+  /// 
+  /// ## **Example Scenarios:**
+  /// 
+  /// ### **Scenario 1: No Blocking Events**
+  /// ```dart
+  /// Event: 9:00-10:00 AM in Column 0
+  /// Right columns: No overlapping events
+  /// Result: Expands to full remaining width
+  /// ```
+  /// 
+  /// ### **Scenario 2: Blocked by Column 2**
+  /// ```dart
+  /// Event: 9:00-11:00 AM in Column 0  
+  /// Column 2: Has event 9:30-10:30 AM (overlaps!)
+  /// Result: Width limited to Column 2's left boundary
+  /// ```
+  /// 
+  /// ### **Scenario 3: Multiple Potential Blocks**
+  /// ```dart
+  /// Event: 9:00-12:00 PM in Column 0
+  /// Column 1: Event 10:00-11:00 AM (overlaps)
+  /// Column 3: Event 11:00-12:00 PM (also overlaps)
+  /// Result: Width limited to Column 1 (first blocking column)
+  /// ```
+  /// 
+  /// ## **Performance Optimizations:**
+  /// - **Early Termination**: Stops scanning at first blocking event
+  /// - **Column-based Scanning**: Only checks relevant columns
+  /// - **Efficient Overlap Detection**: Uses optimized `_eventsOverlap()`
+  /// 
+  /// ## **Edge Cases:**
+  /// - **Rightmost Column**: Gets all remaining space
+  /// - **All Columns Blocked**: Falls back to minimum column width
+  /// - **No Right Columns**: Expands to total width boundary
+  /// - **Zero Available Space**: Guaranteed minimum width prevents layout break
   double _calculateAvailableWidthToRight(
     _NormalizedEvent<T> targetEvent,
     List<List<_NormalizedEvent<T>>> allColumns,
@@ -371,12 +769,78 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
   }
 }
 
-/// Internal class to normalize event data for efficient processing
+/// **Internal Event Data Structure - Normalized Representation**
+/// 
+/// Standardized internal format for events optimized for layout calculations.
+/// Converts complex calendar event data into a simplified, computation-friendly format.
+/// 
+/// ## **Design Purpose:**
+/// - **Performance**: Optimized data structure for layout algorithms
+/// - **Consistency**: Standardized time representation (minutes since midnight)
+/// - **Simplicity**: Removes complexity of original event data during processing
+/// - **Multi-day Support**: Handles events spanning multiple days uniformly
+/// 
+/// ## **Key Fields:**
+/// 
+/// ### **originalEvent**: Reference to source data
+/// - **Type**: `CalendarEventData<T>`
+/// - **Purpose**: Maintains link to original event for final output
+/// - **Usage**: Accessed when creating final organized event data
+/// 
+/// ### **effectiveStartTime**: Normalized start time in minutes
+/// - **Format**: Minutes since midnight (0-1439)
+/// - **Multi-day Logic**: Adjusted for current view date
+/// - **Example**: 2:30 PM = 870 minutes (14.5 * 60)
+/// 
+/// ### **effectiveEndTime**: Normalized end time in minutes  
+/// - **Format**: Minutes since midnight (0-1440)
+/// - **Multi-day Logic**: Adjusted for current view date
+/// - **Boundary**: Can be 1440 (next day) for events ending at midnight
+/// 
+/// ### **isMultiDay**: Multi-day event indicator
+/// - **Purpose**: Tracks whether event spans multiple calendar days
+/// - **Usage**: Affects rendering and time calculations
+/// - **Source**: Derived from `CalendarEventData.isRangingEvent`
+/// 
+/// ### **isFullDay**: Full-day event indicator  
+/// - **Purpose**: Identifies all-day events for special handling
+/// - **Usage**: May affect positioning and rendering logic
+/// - **Source**: Derived from `CalendarEventData.isFullDayEvent`
+/// 
+/// ## **Normalization Benefits:**
+/// - **Uniform Time Format**: All events use same time representation
+/// - **Simplified Comparisons**: Easy overlap detection with integer arithmetic
+/// - **Multi-day Handling**: Complex spanning logic resolved once
+/// - **Performance**: Reduced object complexity for hot path operations
+/// 
+/// ## **Usage Pattern:**
+/// ```dart
+/// // Created during normalization phase
+/// final normalized = _NormalizedEvent<String>(
+///   originalEvent: calendarEvent,
+///   effectiveStartTime: 540, // 9:00 AM  
+///   effectiveEndTime: 660,   // 11:00 AM
+///   isMultiDay: false,
+///   isFullDay: false,
+/// );
+/// 
+/// // Used in overlap detection
+/// if (event1.effectiveEndTime > event2.effectiveStartTime) { ... }
+/// ```
 class _NormalizedEvent<T extends Object?> {
+  /// Reference to the original calendar event data
   final CalendarEventData<T> originalEvent;
+  
+  /// Event start time in minutes since midnight (0-1439)
   final int effectiveStartTime;
+  
+  /// Event end time in minutes since midnight (0-1440)
   final int effectiveEndTime;
+  
+  /// Whether this event spans multiple calendar days
   final bool isMultiDay;
+  
+  /// Whether this is a full-day event
   final bool isFullDay;
 
   const _NormalizedEvent({

--- a/lib/src/event_arrangers/side_event_arranger.dart
+++ b/lib/src/event_arrangers/side_event_arranger.dart
@@ -4,40 +4,11 @@
 
 part of 'event_arrangers.dart';
 
-/// **SideEventArranger: Smart Event Layout Manager**
-/// 
-/// This class arranges overlapping calendar events side by side in an optimal way,
-/// ensuring no visual overlaps while maximizing space utilization.
-/// 
-/// ## **Core Functionality:**
-/// - Arranges overlapping events in separate columns
-/// - Calculates optimal widths for each event based on available space
-/// - Supports both fixed maxWidth constraints and dynamic width allocation
-/// - Handles multi-day events, full-day events, and edge cases
-/// 
-/// ## **Algorithm Overview:**
-/// 1. **Event Normalization**: Converts events to a standardized format for the current view date
-/// 2. **Column Creation**: Uses O(n²) algorithm to group non-overlapping events into columns
-/// 3. **Width Calculation**: Determines optimal width for each event based on available space
-/// 4. **Positioning**: Places events with proper left/right positioning to eliminate gaps
-/// 
-/// ## **Key Features:**
-/// - **Gap Elimination**: Events expand to fill available space when possible
-/// - **Edge Case Handling**: Properly handles touching events, multi-day events, and time boundaries
-/// - **Flexible Width Control**: Supports both fixed maxWidth and dynamic width allocation
-/// - **Performance Optimized**: Efficient algorithms for real-world calendar scenarios
-/// 
-/// ## **Usage Examples:**
-/// ```dart
-/// // Basic usage with dynamic width
-/// final arranger = SideEventArranger<String>();
-/// 
-/// // With maximum width constraint (100px)
-/// final arranger = SideEventArranger<String>(maxWidth: 100.0);
-/// 
-/// // Include touching events as overlapping
-/// final arranger = SideEventArranger<String>(includeEdges: true);
-/// ```
+/// Arranges overlapping calendar events side by side, ensuring no visual overlap and optimal use of space.
+/// Supports multi-day and full-day events, fixed or dynamic width allocation, and configurable edge overlap handling.
+///
+/// Events are grouped into columns to prevent overlaps, and each event is positioned and sized for best readability.
+/// Use [maxWidth] to constrain event width, and [includeEdges] to control whether touching events are treated as overlapping.
 class SideEventArranger<T extends Object?> extends EventArranger<T> {
   /// This class will provide method that will arrange
   /// all the events side by side.
@@ -46,84 +17,28 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     this.includeEdges = false,
   });
 
-  /// **Edge Case Handling Configuration**
-  /// 
-  /// Determines whether events that are touching at their edges should be 
-  /// considered as overlapping and placed in separate columns.
-  /// 
-  /// **Use Cases:**
-  /// - `false` (default): Events like 2:00-3:00 PM and 3:00-4:00 PM can share the same column
-  /// - `true`: Touching events are forced into separate columns for visual clarity
-  /// 
-  /// **Example:**
-  /// ```dart
-  /// // Events: [14:00-15:00], [15:00-16:00]
-  /// // includeEdges = false: Both events in same column (touching is OK)
-  /// // includeEdges = true:  Events in separate columns (touching treated as overlap)
-  /// ```
+  /// Decides whether events that are overlapping on edge
+  /// (ex, event1 has the same end-time as the start-time of event 2)
+  /// should be offset or not.
+  ///
+  /// If includeEdges is true, it will offset the events else it will not.
+  /// Defaults to false.
   final bool includeEdges;
 
-  /// **Maximum Width Constraint (Optional)**
-  /// 
-  /// When specified, limits the maximum width any event can take, regardless
-  /// of available space. This ensures consistent visual appearance.
-  /// 
-  /// **Behavior:**
-  /// - `null` (default): Events expand to fill all available space
-  /// - `double value`: Events are capped at this width in pixels
-  /// 
-  /// **Use Cases:**
-  /// - UI consistency: Prevent events from becoming too wide
-  /// - Mobile optimization: Ensure readable text on narrow screens
-  /// - Design constraints: Match specific layout requirements
-  /// 
-  /// **Example:**
-  /// ```dart
-  /// // Without maxWidth: Event might expand to 400px if space available
-  /// // With maxWidth: 150.0: Event width capped at 150px
-  /// ```
+  /// If enough space is available, the event slot will
+  /// use the specified max width.
+  /// Otherwise, it will reduce to fit all events in the cell.
+  /// If max width is not specified, slots will expand to fill the cell.
   final double? maxWidth;
 
-  /// **Main Event Arrangement Algorithm**
-  /// 
-  /// This is the primary entry point that orchestrates the entire event arrangement process.
-  /// It handles all the complex logic for positioning overlapping events optimally.
-  /// 
-  /// ## **Algorithm Steps:**
-  /// 1. **Input Validation**: Return empty if no events provided
-  /// 2. **Event Normalization**: Convert events to internal format for current date
-  /// 3. **Time-based Sorting**: Order events by start time for optimal processing
-  /// 4. **Column Creation**: Group non-overlapping events into columns
-  /// 5. **Width Calculation**: Determine optimal positioning and sizing
-  /// 
-  /// ## **Input Parameters:**
-  /// - `events`: List of calendar events to arrange (must be sorted by start time)
-  /// - `width`: Total available width for the calendar view
-  /// - `height`: Total available height for the calendar view
-  /// - `heightPerMinute`: Vertical pixels per minute (for time-based positioning)
-  /// - `startHour`: First visible hour (e.g., 8 for 8:00 AM)
-  /// - `calendarViewDate`: The specific date being displayed
-  /// 
-  /// ## **Output:**
-  /// List of `OrganizedCalendarEventData` with calculated positions:
-  /// - `left`: Distance from left edge in pixels
-  /// - `right`: Distance from right edge in pixels  
-  /// - `top`: Distance from top edge in pixels
-  /// - `bottom`: Distance from bottom edge in pixels
-  /// 
-  /// ## **Edge Cases Handled:**
-  /// - Empty event list → Returns empty result
-  /// - Events outside visible time range → Automatically filtered out
-  /// - Multi-day events → Properly clipped to current day view
-  /// - Zero-duration events → Handled with minimum height
-  /// - Events spanning midnight → Correctly processed for day boundaries
-  /// 
-  /// ## **Performance Considerations:**
-  /// - Time Complexity: O(n²) for column creation, O(n) for positioning
-  /// - Space Complexity: O(n) for internal data structures
-  /// - Optimized for typical calendar scenarios (few overlapping events)
-  /// 
-  /// **Prerequisite**: Events must be sorted by start time for optimal results.
+  /// Arranges events for a calendar day view.
+  ///
+  /// Normalizes, sorts, and groups events into columns, then calculates their positions and sizes for rendering.
+  /// Returns a list of [OrganizedCalendarEventData] with pixel positions and event references.
+  ///
+  /// Handles edge cases like empty event lists, events outside the visible range, multi-day events, zero-duration events, and events spanning midnight.
+  ///
+  /// Optimized for typical calendar scenarios. Events should be sorted by start time for
   @override
   List<OrganizedCalendarEventData<T>> arrange({
     required List<CalendarEventData<T>> events,
@@ -155,38 +70,22 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
         heightPerMinute, startHourInMinutes, calendarViewDate);
   }
 
-  /// **Event Normalization for Date-Specific View**
-  /// 
-  /// Converts raw calendar events into a standardized internal format optimized
-  /// for the specific date being displayed. This handles complex multi-day event logic.
-  /// 
-  /// ## **Key Responsibilities:**
-  /// 1. **Multi-day Event Handling**: Clips events to the current day's boundaries
-  /// 2. **Time Range Validation**: Filters out events outside visible hours
-  /// 3. **Data Standardization**: Converts to internal `_NormalizedEvent` format
-  /// 
-  /// ## **Multi-day Event Cases:**
-  /// - **Same Day**: Event starts and ends on the same day → Use original times
-  /// - **Start Day**: Event starts today, ends later → Start at event time, end at day end
-  /// - **End Day**: Event started earlier, ends today → Start at day start, end at event time  
-  /// - **Middle Day**: Event spans multiple days → Full day (start=0, end=1440 minutes)
-  /// 
-  /// ## **Edge Cases Handled:**
-  /// - `null` start/end times → Skipped completely
-  /// - Events outside visible time range → Filtered out
-  /// - Zero-duration events → Processed normally
-  /// - Events crossing midnight → Properly clipped to day boundaries
-  /// 
-  /// ## **Example Scenarios:**
-  /// ```dart
-  /// // Viewing: Jan 2, 2024
-  /// // Event: Jan 1 10:00 PM - Jan 3 2:00 PM
-  /// // Result: Jan 2 0:00 AM - Jan 2 11:59 PM (full day for middle day)
-  /// 
-  /// // Viewing: Jan 15, 2024  
-  /// // Event: Jan 15 2:00 PM - Jan 15 4:00 PM
-  /// // Result: Jan 15 2:00 PM - Jan 15 4:00 PM (same day, unchanged)
-  /// ```
+  /// Normalizes events for the given date.
+  ///
+  /// Clips multi-day events to the current day's boundaries, filters out events outside visible hours,
+  /// and converts each event to a standardized internal format for layout.
+  ///
+  /// Multi-day event cases:
+  /// - Same day: uses original start/end times.
+  /// - Start day: starts at event time, ends at day end.
+  /// - End day: starts at day start, ends at event time.
+  /// - Middle day: uses full day (0–1440 minutes).
+  ///
+  /// Skips events with null times or outside the visible range.
+  ///
+  /// Example:
+  ///   Viewing Jan 2, 2024 for event Jan 1 10:00 PM – Jan 3 2:00 PM
+  ///   → Result: Jan 2 0:00 AM – Jan 2 11:59 PM (full day for middle day)
   List<_NormalizedEvent<T>> _normalizeEventsForDate(
     List<CalendarEventData<T>> events,
     DateTime calendarViewDate,
@@ -251,43 +150,12 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     return normalizedEvents;
   }
 
-  /// **Column Creation Algorithm - Event Grouping Strategy**
-  /// 
-  /// Groups events into columns where no two events in the same column overlap.
-  /// This is the core algorithm that determines the layout structure.
-  /// 
-  /// ## **Algorithm Logic:**
-  /// 1. **Sequential Processing**: Process events one by one in chronological order
-  /// 2. **Column Search**: For each event, find the first available column where it fits
-  /// 3. **Collision Detection**: Use `_canEventFitInColumn` to check for overlaps
-  /// 4. **New Column Creation**: If no existing column works, create a new one
-  /// 
-  /// ## **Time Complexity:** 
-  /// - **Best Case**: O(n) - All events sequential, no overlaps
-  /// - **Worst Case**: O(n²) - All events overlap, each needs new column
-  /// - **Typical Case**: O(n*k) where k is average number of columns (~3-5)
-  /// 
-  /// ## **Column Selection Strategy:**
-  /// Uses **First-Fit** approach: Always tries to place event in the leftmost available column.
-  /// This minimizes the total number of columns needed and creates compact layouts.
-  /// 
-  /// ## **Example Walkthrough:**
-  /// ```dart
-  /// Events: [9:00-10:00], [9:30-11:00], [10:30-12:00], [11:30-13:00]
-  /// 
-  /// Step 1: [9:00-10:00] → Column 0 (first event)
-  /// Step 2: [9:30-11:00] → Column 1 (overlaps with Column 0)
-  /// Step 3: [10:30-12:00] → Column 0 (fits after first event ends)
-  /// Step 4: [11:30-13:00] → Column 1 (fits after second event ends)
-  /// 
-  /// Result: 2 columns, optimal layout
-  /// ```
-  /// 
-  /// ## **Edge Cases:**
-  /// - **Empty Input**: Returns empty column list
-  /// - **Single Event**: Creates one column with one event
-  /// - **No Overlaps**: All events in single column (most compact)
-  /// - **All Events Overlap**: Each event gets its own column
+  /// Groups events into columns so that no two events in the same column overlap.
+  ///
+  /// Uses a first-fit approach: each event is placed in the leftmost column where it does not overlap with existing events.
+  /// This minimizes the number of columns and creates a compact layout.
+  ///
+  /// Handles edge cases like empty input, single events, no overlaps, and all events overlapping.
   List<List<_NormalizedEvent<T>>> _createOptimalColumns(
       List<_NormalizedEvent<T>> events) {
     if (events.isEmpty) return [];
@@ -316,26 +184,12 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     return columns;
   }
 
-  /// **Column Fit Testing - Overlap Detection**
-  /// 
-  /// Determines whether a new event can be placed in an existing column
-  /// without overlapping with any events already in that column.
-  /// 
-  /// ## **Algorithm:**
-  /// 1. **Iterate through existing events** in the target column
-  /// 2. **Check overlap** with each existing event using `_eventsOverlap`
-  /// 3. **Return false** immediately if any overlap is found (early termination)
-  /// 4. **Return true** only if no overlaps detected
-  /// 
-  /// ## **Performance Optimization:**
-  /// - **Early Exit**: Stops checking as soon as first overlap is found
-  /// - **Time Complexity**: O(k) where k is events in column (typically 1-3)
-  /// - **Space Complexity**: O(1) - no additional storage needed
-  /// 
-  /// ## **Use Cases:**
-  /// - Column selection during event placement
-  /// - Validation of layout correctness
-  /// - Debugging overlap detection issues
+  /// Returns true if a new event can be placed in a column without overlapping any existing events.
+  ///
+  /// Iterates through events in the target column and returns false immediately if any overlap is found.
+  /// Optimized for early exit and minimal memory usage.
+  ///
+  /// Used for column selection and layout validation.
   bool _canEventFitInColumn(
       _NormalizedEvent<T> event, List<_NormalizedEvent<T>> column) {
     for (final existing in column) {
@@ -346,47 +200,13 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     return true;
   }
 
-  /// **Temporal Overlap Detection - Core Logic**
-  /// 
-  /// Determines whether two events overlap in time, considering the `includeEdges` setting.
-  /// This is the fundamental building block for all layout decisions.
-  /// 
-  /// ## **Overlap Logic:**
-  /// 
-  /// ### **When includeEdges = false (default):**
-  /// Events that touch at edges are NOT considered overlapping.
-  /// ```dart
-  /// Event A: 14:00-15:00, Event B: 15:00-16:00 → No overlap (touching is OK)
-  /// Event A: 14:00-15:30, Event B: 15:00-16:00 → Overlap (actual time conflict)
-  /// ```
-  /// 
-  /// ### **When includeEdges = true:**
-  /// Events that touch at edges ARE considered overlapping.
-  /// ```dart
-  /// Event A: 14:00-15:00, Event B: 15:00-16:00 → Overlap (touching treated as conflict)
-  /// Event A: 14:00-15:30, Event B: 15:00-16:00 → Overlap (actual time conflict)
-  /// ```
-  /// 
-  /// ## **Mathematical Formulation:**
-  /// For events with times (start1, end1) and (start2, end2):
-  /// 
-  /// **includeEdges = false:**
-  /// - Overlap if: `start1 < end2 AND start2 < end1`
-  /// - No overlap if events just touch: `end1 == start2`
-  /// 
-  /// **includeEdges = true:**
-  /// - Overlap if: `start1 <= end2 AND start2 <= end1`
-  /// - Overlap even if events just touch: `end1 == start2`
-  /// 
-  /// ## **Edge Cases:**
-  /// - **Zero Duration Events**: Point events (start == end) handled correctly
-  /// - **Same Start/End Times**: Identical events always overlap
-  /// - **Reversed Time Order**: Algorithm works regardless of parameter order
-  /// 
-  /// ## **Performance:**
-  /// - **Time Complexity**: O(1) - Simple arithmetic comparisons
-  /// - **Space Complexity**: O(1) - No additional storage
-  /// - **Highly Optimized**: Used in tight loops, marked for inlining
+  /// Returns true if two events overlap in time, considering [includeEdges].
+  ///
+  /// If [includeEdges] is false, events that only touch at edges are not considered overlapping.
+  /// If true, touching events are treated as overlapping.
+  ///
+  /// Handles edge cases like zero-duration events and identical start/end times.
+  /// Optimized for fast arithmetic comparison.
   bool _eventsOverlap(_NormalizedEvent<T> event1, _NormalizedEvent<T> event2) {
     if (includeEdges) {
       // Events overlap if they have any overlapping time (including touching edges)
@@ -399,41 +219,13 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     }
   }
 
-  /// **Layout Strategy Coordinator - Width Allocation Decision**
-  /// 
-  /// Orchestrates the final positioning phase by choosing between two different
-  /// width allocation strategies based on the `maxWidth` configuration.
-  /// 
-  /// ## **Strategy Selection:**
-  /// 
-  /// ### **Fixed MaxWidth Strategy** (`maxWidth != null`):
-  /// - **Use Case**: Consistent visual appearance, mobile-friendly layouts
-  /// - **Behavior**: Events respect the maxWidth constraint
-  /// - **Benefits**: Predictable sizing, prevents overly wide events
-  /// - **Method**: `_processWithFixedMaxWidth()`
-  /// 
-  /// ### **Dynamic Width Strategy** (`maxWidth == null`):
-  /// - **Use Case**: Maximum space utilization, desktop layouts
-  /// - **Behavior**: Events expand to fill all available space
-  /// - **Benefits**: No wasted space, optimal readability
-  /// - **Method**: `_processWithDynamicWidth()`
-  /// 
-  /// ## **Common Processing Steps:**
-  /// 1. **Time Calculations**: Convert event times to pixel positions
-  /// 2. **Width Calculations**: Determine optimal width for each event
-  /// 3. **Position Calculations**: Calculate left/right positioning
-  /// 4. **Result Generation**: Create `OrganizedCalendarEventData` objects
-  /// 
-  /// ## **Output Format:**
-  /// Each event becomes an `OrganizedCalendarEventData` with:
-  /// - **Spatial Data**: left, right, top, bottom positions in pixels
-  /// - **Temporal Data**: startDuration, endDuration for time references
-  /// - **Event Data**: Reference to original event and metadata
-  /// 
-  /// ## **Error Handling:**
-  /// - **Empty Columns**: Returns empty result gracefully
-  /// - **Invalid Dimensions**: Protected by bounds checking
-  /// - **Calculation Errors**: Math.max/min prevent negative values
+  /// Converts columns to organized event data and calculates positions and sizes for rendering.
+  ///
+  /// Uses either fixed maxWidth or dynamic width allocation based on [maxWidth].
+  /// Handles time and width calculations, positioning, and result generation.
+  ///
+  /// Returns a list of [OrganizedCalendarEventData] with pixel positions and event references.
+  /// Handles empty columns and invalid dimensions gracefully.
   List<OrganizedCalendarEventData<T>> _convertColumnsToOrganizedData(
     List<List<_NormalizedEvent<T>>> columns,
     double totalWidth,
@@ -461,40 +253,12 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     return result;
   }
 
-  /// **Fixed MaxWidth Processing - Constrained Layout Strategy**
-  /// 
   /// Handles event positioning when a maximum width constraint is specified.
-  /// This strategy balances space utilization with visual consistency.
-  /// 
-  /// ## **Core Algorithm:**
-  /// 1. **Width Pre-calculation**: Calculate optimal width for each event
-  /// 2. **MaxWidth Application**: Cap event widths at the specified maximum
-  /// 3. **Gap Elimination**: Position events to minimize empty space
-  /// 4. **Column-based Positioning**: Use actual column widths for positioning
-  /// 
-  /// ## **Width Calculation Process:**
-  /// ```dart
-  /// For each event:
-  ///   1. Calculate available space to the right
-  ///   2. Apply maxWidth constraint: min(available, maxWidth)
-  ///   3. Store in eventWidths map for positioning phase
-  /// ```
-  /// 
-  /// ## **Positioning Strategy:**
-  /// - **Column Width**: Use the widest event in each column to determine column width
-  /// - **Left Position**: Accumulate column widths to eliminate gaps
-  /// - **Right Position**: Calculate remaining space after event width
-  /// 
-  /// ## **Benefits:**
-  /// - **Consistent Appearance**: No event exceeds maxWidth limit
-  /// - **Optimal Space Usage**: Events expand up to the constraint
-  /// - **Gap-Free Layout**: Columns positioned adjacently
-  /// - **Mobile Friendly**: Prevents overly wide events on small screens
-  /// 
-  /// ## **Edge Cases:**
-  /// - **MaxWidth > Available Space**: Event uses available space (no artificial padding)
-  /// - **Multiple Events in Column**: All respect the same maxWidth constraint
-  /// - **Very Small MaxWidth**: Events maintain minimum readability
+  ///
+  /// Calculates optimal width for each event, applies [maxWidth], and positions events to minimize gaps.
+  /// Uses actual column widths for positioning and ensures consistent appearance.
+  ///
+  /// Handles edge cases like maxWidth exceeding available space, multiple events per column, and very small maxWidth values.
   void _processWithFixedMaxWidth(
     List<List<_NormalizedEvent<T>>> columns,
     List<OrganizedCalendarEventData<T>> result,
@@ -570,49 +334,12 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     }
   }
 
-  /// **Dynamic Width Processing - Maximum Space Utilization Strategy**
-  /// 
   /// Handles event positioning when no maximum width constraint is specified.
-  /// Events expand to use all available space for optimal readability.
-  /// 
-  /// ## **Core Philosophy:**
-  /// Maximize the use of available horizontal space while maintaining proper
-  /// visual separation between overlapping events.
-  /// 
-  /// ## **Algorithm Steps:**
-  /// 1. **Equal Column Distribution**: Start with equal-width columns as baseline
-  /// 2. **Available Space Calculation**: Determine how much each event can expand
-  /// 3. **Rightward Expansion**: Events extend rightward until blocked by overlapping events
-  /// 4. **Standard Positioning**: Use column-based left positioning for consistency
-  /// 
-  /// ## **Width Expansion Logic:**
-  /// ```dart
-  /// For each event:
-  ///   1. Start at column left boundary
-  ///   2. Expand rightward until hitting overlapping event or boundary
-  ///   3. Use calculated available width for the event
-  /// ```
-  /// 
-  /// ## **Column Positioning:**
-  /// - **Left Position**: Based on equal column distribution (`columnIndex * baseWidth`)
-  /// - **Event Width**: Uses `_calculateAvailableWidthToRight()` for optimal expansion
-  /// - **Right Position**: Calculated as `totalWidth - left - eventWidth`
-  /// 
-  /// ## **Benefits:**
-  /// - **Maximum Readability**: Events use all available space
-  /// - **No Wasted Space**: Horizontal area fully utilized
-  /// - **Smart Expansion**: Events stop at logical boundaries
-  /// - **Desktop Optimized**: Ideal for larger screens
-  /// 
-  /// ## **Use Cases:**
-  /// - **Desktop Calendars**: Large screens with plenty of horizontal space
-  /// - **Print Layouts**: Maximum information density required
-  /// - **Detail Views**: When event content needs maximum width
-  /// 
-  /// ## **Edge Cases:**
-  /// - **Single Column**: Event expands to full width
-  /// - **Many Overlaps**: Events get narrow but fair space allocation
-  /// - **Variable Content**: Width adapts to optimal display needs
+  ///
+  /// Events expand to use all available horizontal space for optimal readability, stopping at overlapping events in columns to the right.
+  /// Uses equal column distribution for left positioning and calculates available width for each event.
+  ///
+  /// Ensures maximum readability, no wasted space, and adapts to variable content and overlap scenarios.
   void _processWithDynamicWidth(
     List<List<_NormalizedEvent<T>>> columns,
     List<OrganizedCalendarEventData<T>> result,
@@ -667,67 +394,12 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     }
   }
 
-  /// **Available Width Calculation - Smart Space Detection**
-  /// 
-  /// Calculates how much horizontal space an event can use by analyzing
-  /// the layout to the right and detecting blocking overlapping events.
-  /// 
-  /// ## **Core Algorithm:**
-  /// 1. **Baseline Calculation**: Start with remaining space from current position to edge
-  /// 2. **Right-side Scanning**: Check each column to the right for blocking events
-  /// 3. **Overlap Detection**: Use `_eventsOverlap()` to find temporal conflicts
-  /// 4. **Width Limiting**: Stop expansion at first blocking event found
-  /// 5. **Minimum Guarantee**: Ensure at least one column width is available
-  /// 
-  /// ## **Scanning Strategy:**
-  /// ```dart
-  /// For each column to the right:
-  ///   For each event in that column:
-  ///     If event overlaps with target:
-  ///       Limit width to that column's position
-  ///       Break (stop scanning further right)
-  /// ```
-  /// 
-  /// ## **Width Calculation Logic:**
-  /// - **Initial Width**: `totalWidth - startPosition` (all remaining space)
-  /// - **Blocking Position**: `rightColumnIndex * baseSlotWidth`
-  /// - **Final Width**: `blockingPosition - startPosition`
-  /// - **Minimum Width**: `max(baseSlotWidth, calculatedWidth)`
-  /// 
-  /// ## **Example Scenarios:**
-  /// 
-  /// ### **Scenario 1: No Blocking Events**
-  /// ```dart
-  /// Event: 9:00-10:00 AM in Column 0
-  /// Right columns: No overlapping events
-  /// Result: Expands to full remaining width
-  /// ```
-  /// 
-  /// ### **Scenario 2: Blocked by Column 2**
-  /// ```dart
-  /// Event: 9:00-11:00 AM in Column 0  
-  /// Column 2: Has event 9:30-10:30 AM (overlaps!)
-  /// Result: Width limited to Column 2's left boundary
-  /// ```
-  /// 
-  /// ### **Scenario 3: Multiple Potential Blocks**
-  /// ```dart
-  /// Event: 9:00-12:00 PM in Column 0
-  /// Column 1: Event 10:00-11:00 AM (overlaps)
-  /// Column 3: Event 11:00-12:00 PM (also overlaps)
-  /// Result: Width limited to Column 1 (first blocking column)
-  /// ```
-  /// 
-  /// ## **Performance Optimizations:**
-  /// - **Early Termination**: Stops scanning at first blocking event
-  /// - **Column-based Scanning**: Only checks relevant columns
-  /// - **Efficient Overlap Detection**: Uses optimized `_eventsOverlap()`
-  /// 
-  /// ## **Edge Cases:**
-  /// - **Rightmost Column**: Gets all remaining space
-  /// - **All Columns Blocked**: Falls back to minimum column width
-  /// - **No Right Columns**: Expands to total width boundary
-  /// - **Zero Available Space**: Guaranteed minimum width prevents layout break
+  /// Calculates how much horizontal space an event can use by checking for blocking events in columns to the right.
+  ///
+  /// Scans columns to the right and limits width at the first blocking event, guaranteeing a minimum width.
+  /// Optimized for early exit and efficient overlap detection.
+  ///
+  /// Handles edge cases like rightmost columns, all columns blocked, and zero available space.
   double _calculateAvailableWidthToRight(
     _NormalizedEvent<T> targetEvent,
     List<List<_NormalizedEvent<T>>> allColumns,
@@ -769,77 +441,23 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
   }
 }
 
-/// **Internal Event Data Structure - Normalized Representation**
-/// 
-/// Standardized internal format for events optimized for layout calculations.
-/// Converts complex calendar event data into a simplified, computation-friendly format.
-/// 
-/// ## **Design Purpose:**
-/// - **Performance**: Optimized data structure for layout algorithms
-/// - **Consistency**: Standardized time representation (minutes since midnight)
-/// - **Simplicity**: Removes complexity of original event data during processing
-/// - **Multi-day Support**: Handles events spanning multiple days uniformly
-/// 
-/// ## **Key Fields:**
-/// 
-/// ### **originalEvent**: Reference to source data
-/// - **Type**: `CalendarEventData<T>`
-/// - **Purpose**: Maintains link to original event for final output
-/// - **Usage**: Accessed when creating final organized event data
-/// 
-/// ### **effectiveStartTime**: Normalized start time in minutes
-/// - **Format**: Minutes since midnight (0-1439)
-/// - **Multi-day Logic**: Adjusted for current view date
-/// - **Example**: 2:30 PM = 870 minutes (14.5 * 60)
-/// 
-/// ### **effectiveEndTime**: Normalized end time in minutes  
-/// - **Format**: Minutes since midnight (0-1440)
-/// - **Multi-day Logic**: Adjusted for current view date
-/// - **Boundary**: Can be 1440 (next day) for events ending at midnight
-/// 
-/// ### **isMultiDay**: Multi-day event indicator
-/// - **Purpose**: Tracks whether event spans multiple calendar days
-/// - **Usage**: Affects rendering and time calculations
-/// - **Source**: Derived from `CalendarEventData.isRangingEvent`
-/// 
-/// ### **isFullDay**: Full-day event indicator  
-/// - **Purpose**: Identifies all-day events for special handling
-/// - **Usage**: May affect positioning and rendering logic
-/// - **Source**: Derived from `CalendarEventData.isFullDayEvent`
-/// 
-/// ## **Normalization Benefits:**
-/// - **Uniform Time Format**: All events use same time representation
-/// - **Simplified Comparisons**: Easy overlap detection with integer arithmetic
-/// - **Multi-day Handling**: Complex spanning logic resolved once
-/// - **Performance**: Reduced object complexity for hot path operations
-/// 
-/// ## **Usage Pattern:**
-/// ```dart
-/// // Created during normalization phase
-/// final normalized = _NormalizedEvent<String>(
-///   originalEvent: calendarEvent,
-///   effectiveStartTime: 540, // 9:00 AM  
-///   effectiveEndTime: 660,   // 11:00 AM
-///   isMultiDay: false,
-///   isFullDay: false,
-/// );
-/// 
-/// // Used in overlap detection
-/// if (event1.effectiveEndTime > event2.effectiveStartTime) { ... }
-/// ```
+/// Internal event data structure for calendar layout.
+///
+/// Stores normalized start/end times (minutes since midnight), multi-day/full-day flags, and a reference to the original event.
+/// Used for efficient overlap detection, layout calculations, and rendering in calendar views.
 class _NormalizedEvent<T extends Object?> {
   /// Reference to the original calendar event data
   final CalendarEventData<T> originalEvent;
-  
+
   /// Event start time in minutes since midnight (0-1439)
   final int effectiveStartTime;
-  
+
   /// Event end time in minutes since midnight (0-1440)
   final int effectiveEndTime;
-  
+
   /// Whether this event spans multiple calendar days
   final bool isMultiDay;
-  
+
   /// Whether this is a full-day event
   final bool isFullDay;
 

--- a/lib/src/event_arrangers/side_event_arranger.dart
+++ b/lib/src/event_arrangers/side_event_arranger.dart
@@ -5,8 +5,8 @@
 part of 'event_arrangers.dart';
 
 /// Arranges overlapping calendar events side by side, ensuring no visual overlap and optimal use of space.
-/// Supports multi-day and full-day events, fixed or dynamic width allocation, and configurable edge overlap handling.
-///
+/// Supports multi-day and full-day events, fixed or dynamic width allocation, and configurable
+/// edge overlap handling via [countAdjacentEventsAsOverlapping].
 /// Events are grouped into columns to prevent overlaps, and each event is positioned and sized for best readability.
 /// Use [maxWidth] to constrain event width, and [countAdjacentEventsAsOverlapping] to control whether touching events are treated as overlapping.
 class SideEventArranger<T extends Object?> extends EventArranger<T> {
@@ -141,16 +141,22 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
 
         if (isStartDate && isEndDate) {
           // Event starts and ends on the same day (single day spanning event)
+          // endTime of 0 (midnight) is treated as end-of-day (1440)
           effectiveStartTime = event.startTime!.getTotalMinutes;
-          effectiveEndTime = event.endTime!.getTotalMinutes;
+          final endMinutes = event.endTime!.getTotalMinutes;
+          effectiveEndTime =
+              endMinutes == 0 ? Constants.minutesADay : endMinutes;
         } else if (isStartDate) {
           // First day of multi-day event - start at event time, end at day end
           effectiveStartTime = event.startTime!.getTotalMinutes;
           effectiveEndTime = Constants.minutesADay;
         } else if (isEndDate) {
           // Last day of multi-day event - start at day start, end at event time
+          // endTime of 0 (midnight) is treated as end-of-day (1440)
           effectiveStartTime = 0;
-          effectiveEndTime = event.endTime!.getTotalMinutes;
+          final endMinutes = event.endTime!.getTotalMinutes;
+          effectiveEndTime =
+              endMinutes == 0 ? Constants.minutesADay : endMinutes;
         } else {
           // Middle day of multi-day event - full day
           effectiveStartTime = 0;
@@ -158,8 +164,10 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
         }
       } else {
         // Regular single-day event
+        // endTime of 0 (midnight) is treated as end-of-day (1440)
         effectiveStartTime = event.startTime!.getTotalMinutes;
-        effectiveEndTime = event.endTime!.getTotalMinutes;
+        final endMinutes = event.endTime!.getTotalMinutes;
+        effectiveEndTime = endMinutes == 0 ? Constants.minutesADay : endMinutes;
       }
 
       // Skip events that don't appear in the visible time range
@@ -175,8 +183,6 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
         originalEvent: event,
         effectiveStartTime: effectiveStartTime,
         effectiveEndTime: effectiveEndTime,
-        isMultiDay: event.isRangingEvent,
-        isFullDay: event.isFullDayEvent,
       ));
     }
 
@@ -304,8 +310,10 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     final columnCount = columns.length;
     if (columnCount == 0) return;
 
-    // Calculate actual widths for all events first to avoid gaps
-    final eventWidths = <int, double>{};
+    // Calculate actual widths for all events first to avoid gaps.
+    // Keyed on the _NormalizedEvent instance (identity equality) to avoid the
+    // hash collisions that would occur when using normalizedEvent.hashCode.
+    final eventWidths = <_NormalizedEvent<T>, double>{};
     for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
       final column = columns[columnIndex];
       for (final normalizedEvent in column) {
@@ -315,8 +323,7 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
 
         // Take minimum of dynamic width and maxWidth (maxWidth is absolute pixels)
         final maxWidthPixels = maxWidth!;
-        eventWidths[normalizedEvent.hashCode] =
-            math.min(dynamicWidth, maxWidthPixels);
+        eventWidths[normalizedEvent] = math.min(dynamicWidth, maxWidthPixels);
       }
     }
 
@@ -326,11 +333,13 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
       final column = columns[columnIndex];
 
-      // Find the maximum width needed for this column
-      double maxColumnWidth = double.maxFinite;
+      // All events in the column must share the same width: the minimum of their
+      // individual available widths. This guarantees no event overflows into the
+      // rendered region of the next column.
+      double columnWidth = double.maxFinite;
       for (final normalizedEvent in column) {
-        final eventWidth = eventWidths[normalizedEvent.hashCode]!;
-        maxColumnWidth = math.min(maxColumnWidth, eventWidth);
+        final eventWidth = eventWidths[normalizedEvent]!;
+        columnWidth = math.min(columnWidth, eventWidth);
       }
 
       for (final normalizedEvent in column) {
@@ -342,8 +351,6 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
             Constants.minutesADay - startHourInMinutes,
             normalizedEvent.effectiveEndTime - startHourInMinutes);
 
-        final actualWidth = eventWidths[normalizedEvent.hashCode]!;
-
         final top = displayStartTime * heightPerMinute;
         final visibleMinutes = Constants.minutesADay - startHourInMinutes;
         final bottom = displayEndTime >= visibleMinutes
@@ -352,7 +359,7 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
 
         result.add(OrganizedCalendarEventData<T>(
           left: currentLeftPosition,
-          right: math.max(0.0, totalWidth - currentLeftPosition - actualWidth),
+          right: math.max(0.0, totalWidth - currentLeftPosition - columnWidth),
           top: top,
           bottom: bottom,
           startDuration: event.startTime!.copyFromMinutes(displayStartTime),
@@ -362,8 +369,8 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
         ));
       }
 
-      // Move to next column position based on actual width used
-      currentLeftPosition += maxColumnWidth;
+      // Advance by the shared column width so subsequent columns don't overlap.
+      currentLeftPosition += columnWidth;
     }
   }
 
@@ -476,8 +483,8 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
 
 /// Internal event data structure for calendar layout.
 ///
-/// Stores normalized start/end times (minutes since midnight), multi-day/full-day flags, and a reference to the original event.
-/// Used for efficient overlap detection, layout calculations, and rendering in calendar views.
+/// Stores normalized start/end times (minutes since midnight) and a reference
+/// to the original event. Used for overlap detection and layout calculations.
 class _NormalizedEvent<T extends Object?> {
   /// Reference to the original calendar event data
   final CalendarEventData<T> originalEvent;
@@ -485,20 +492,12 @@ class _NormalizedEvent<T extends Object?> {
   /// Event start time in minutes since midnight (0-1439)
   final int effectiveStartTime;
 
-  /// Event end time in minutes since midnight (0-1440)
+  /// Event end time in minutes since midnight (1-1440)
   final int effectiveEndTime;
-
-  /// Whether this event spans multiple calendar days
-  final bool isMultiDay;
-
-  /// Whether this is a full-day event
-  final bool isFullDay;
 
   const _NormalizedEvent({
     required this.originalEvent,
     required this.effectiveStartTime,
     required this.effectiveEndTime,
-    required this.isMultiDay,
-    required this.isFullDay,
   });
 }

--- a/lib/src/event_arrangers/side_event_arranger.dart
+++ b/lib/src/event_arrangers/side_event_arranger.dart
@@ -40,248 +40,350 @@ class SideEventArranger<T extends Object?> extends EventArranger<T> {
     required int startHour,
     required DateTime calendarViewDate,
   }) {
-    final totalWidth = width;
+    if (events.isEmpty) return [];
+
     final startHourInMinutes = startHour * 60;
 
-    List<_SideEventConfigs<T>> _categorizedColumnedEvents(
-        List<CalendarEventData<T>> events) {
-      final merged = MergeEventArranger<T>(includeEdges: includeEdges).arrange(
-        events: events,
-        height: height,
-        width: width,
-        heightPerMinute: heightPerMinute,
-        startHour: startHour,
-        calendarViewDate: calendarViewDate,
-      );
+    // Step 1: Normalize all events for the current calendar view date
+    final normalizedEvents =
+        _normalizeEventsForDate(events, calendarViewDate, startHourInMinutes);
 
-      final arranged = <_SideEventConfigs<T>>[];
+    if (normalizedEvents.isEmpty) return [];
 
-      for (final event in merged) {
-        if (event.events.isEmpty) {
-          // NOTE(parth): This is safety condition.
-          // This condition should never be true.
-          // If by chance this becomes true, there is something wrong with
-          // logic. And that need to be fixed ASAP.
+    // Step 2: Sort events by start time for optimal processing
+    normalizedEvents
+        .sort((a, b) => a.effectiveStartTime.compareTo(b.effectiveStartTime));
 
-          continue;
-        }
+    // Step 3: Create columns using an efficient sweep line algorithm
+    final columns = _createOptimalColumns(normalizedEvents);
 
-        if (event.events.length > 1) {
-          // NOTE: This means all the events are overlapping with each other.
-          // So, we will extract all the events that can be fit in
-          // Single column without overlapping and run the function
-          // again for the rest of the events.
-          final endMinutes = event.endDuration.getTotalMinutes == 0
-              ? 1440
-              : event.endDuration.getTotalMinutes;
-          final columnedEvents = _extractSingleColumnEvents(
-            event.events,
-            endMinutes,
-            calendarViewDate,
-          );
-
-          final sided = _categorizedColumnedEvents(
-            event.events.where((e) => !columnedEvents.contains(e)).toList(),
-          );
-
-          var maxColumns = 1;
-
-          for (final event in sided) {
-            if (event.columns > maxColumns) {
-              maxColumns = event.columns;
-            }
-          }
-
-          arranged.add(_SideEventConfigs(
-            columns: maxColumns + 1,
-            event: columnedEvents,
-            sideEvents: sided,
-          ));
-        } else {
-          // If this block gets executed that means we have only one event.
-          // Return the event as is.
-
-          arranged.add(_SideEventConfigs(columns: 1, event: event.events));
-        }
-      }
-
-      return arranged;
-    }
-
-    List<OrganizedCalendarEventData<T>> _arrangeEvents(
-        List<_SideEventConfigs<T>> events, double width, double offset) {
-      final arranged = <OrganizedCalendarEventData<T>>[];
-
-      for (final event in events) {
-        final slotWidth =
-            math.min(width / event.columns, maxWidth ?? double.maxFinite);
-
-        if (event.event.isNotEmpty) {
-          arranged.addAll(event.event.map((e) {
-            final startTime = e.startTime!;
-            final endTime = e.endTime!;
-
-            // Use visible time calculation for multi-day event support
-            final visibleStart =
-                e.getVisibleStartMinutes(calendarViewDate.withoutTime);
-            final visibleEnd =
-                e.getVisibleEndMinutes(calendarViewDate.withoutTime);
-
-            // Calculate event times relative to startHour
-            int eventStart = visibleStart - startHourInMinutes;
-            int eventEnd = visibleEnd - startHourInMinutes;
-
-            // Ensure values are within valid range
-            // Clamp to [0, minutesInView] where minutesInView = 1440 - startHourInMinutes
-            eventStart = math.max(0, eventStart);
-            eventEnd = math.max(0, eventEnd); // Prevent negative values
-            eventEnd = math.min(
-              Constants.minutesADay - startHourInMinutes,
-              eventEnd,
-            );
-
-            final top = eventStart * heightPerMinute;
-
-            // Calculate visibleMinutes (the total minutes displayed in the view)
-            final visibleMinutes = Constants.minutesADay - (startHourInMinutes);
-
-            // Check if event ends at or beyond the visible area
-            final bottom = eventEnd >= visibleMinutes
-                ? 0.0 // Event extends to bottom of view
-                : height - eventEnd * heightPerMinute;
-
-            return OrganizedCalendarEventData<T>(
-              left: offset,
-              right: totalWidth - (offset + slotWidth),
-              top: top,
-              bottom: bottom,
-              startDuration: startTime.copyFromMinutes(eventStart),
-              endDuration: endTime.copyFromMinutes(eventEnd),
-              events: [e],
-              calendarViewDate: calendarViewDate,
-            );
-          }));
-        }
-
-        if (event.sideEvents.isNotEmpty) {
-          arranged.addAll(_arrangeEvents(
-            event.sideEvents,
-            math.max(0, width - slotWidth),
-            slotWidth + offset,
-          ));
-        }
-      }
-
-      return arranged;
-    }
-
-    // By default the offset will be 0.
-
-    final columned = _categorizedColumnedEvents(events);
-    final arranged = _arrangeEvents(columned, totalWidth, 0);
-    return arranged;
+    // Step 4: Convert columns to organized calendar event data
+    return _convertColumnsToOrganizedData(columns, width, height,
+        heightPerMinute, startHourInMinutes, calendarViewDate);
   }
 
-  List<CalendarEventData<T>> _extractSingleColumnEvents(
-      List<CalendarEventData<T>> events, int end, DateTime calendarViewDate) {
-    final calendarDate = calendarViewDate.withoutTime;
+  /// Normalizes events for the specific calendar view date
+  List<_NormalizedEvent<T>> _normalizeEventsForDate(
+    List<CalendarEventData<T>> events,
+    DateTime calendarViewDate,
+    int startHourInMinutes,
+  ) {
+    final normalizedEvents = <_NormalizedEvent<T>>[];
 
-    // Find the longest visible event on this calendar date
-    final longestEvent = events.fold<CalendarEventData<T>>(
-      events.first,
-      (e1, e2) => e1.getVisibleDuration(calendarDate) >
-              e2.getVisibleDuration(calendarDate)
-          ? e1
-          : e2,
-    );
+    for (final event in events) {
+      if (event.startTime == null || event.endTime == null) continue;
 
-    // Create a new list from events and remove the longest one from it.
-    final searchEvents = [...events]..remove(longestEvent);
+      int effectiveStartTime;
+      int effectiveEndTime;
 
-    // Create a new list for events in single column.
-    final columnedEvents = [longestEvent];
+      if (event.isRangingEvent) {
+        // Handle multi-day events based on which day we're viewing
+        final isStartDate =
+            calendarViewDate.isAtSameMomentAs(event.date.withoutTime);
+        final isEndDate =
+            calendarViewDate.isAtSameMomentAs(event.endDate.withoutTime);
 
-    // Calculate effective end minute from latest columned event.
-    var endMinutes = longestEvent.getVisibleEndMinutes(calendarDate);
-
-    // Run the loop while effective end minute of columned events are
-    // less than end.
-    while (endMinutes < end && searchEvents.isNotEmpty) {
-      // Maps the event with it's duration.
-      final mappings = <int, CalendarEventData<T>>{};
-
-      // Create a new list from searchEvents.
-      for (final event in [...searchEvents]) {
-        // Check if event overlaps with ANY event in columnedEvents
-        var hasOverlap = false;
-
-        // Get visible time range for event on this calendar date
-        final eventStart = event.getVisibleStartMinutes(calendarDate);
-        final eventEnd = event.getVisibleEndMinutes(calendarDate);
-
-        for (final columnedEvent in columnedEvents) {
-          // Get visible time range for columnedEvent on this calendar date
-          final columnedStart =
-              columnedEvent.getVisibleStartMinutes(calendarDate);
-          final columnedEnd = columnedEvent.getVisibleEndMinutes(calendarDate);
-
-          // Check for overlap
-          final overlaps =
-              (eventStart < columnedEnd && eventEnd > columnedStart) ||
-                  (includeEdges &&
-                      (eventStart == columnedEnd || eventEnd == columnedStart));
-
-          if (overlaps) {
-            hasOverlap = true;
-            break;
-          }
-        }
-
-        if (hasOverlap) {
-          searchEvents.remove(event);
+        if (isStartDate && isEndDate) {
+          // Event starts and ends on the same day (single day spanning event)
+          effectiveStartTime = event.startTime!.getTotalMinutes;
+          effectiveEndTime = event.endTime!.getTotalMinutes;
+        } else if (isStartDate) {
+          // First day of multi-day event - start at event time, end at day end
+          effectiveStartTime = event.startTime!.getTotalMinutes;
+          effectiveEndTime = Constants.minutesADay;
+        } else if (isEndDate) {
+          // Last day of multi-day event - start at day start, end at event time
+          effectiveStartTime = 0;
+          effectiveEndTime = event.endTime!.getTotalMinutes;
         } else {
-          final diff = eventStart - endMinutes;
-          mappings.addAll({
-            diff: event,
-          });
+          // Middle day of multi-day event - full day
+          effectiveStartTime = 0;
+          effectiveEndTime = Constants.minutesADay;
         }
-      }
-
-      // Sentinel value for finding minimum time difference between events.
-      // Must be larger than any possible time difference in a day (max = 1440 minutes).
-      // Using 3x Constants.minutesADay to ensure it's always greater than max difference.
-      const maxPossibleMinuteDifference = Constants.minutesADay * 3;
-      var min = maxPossibleMinuteDifference;
-
-      for (final mapping in mappings.entries) {
-        if (mapping.key < min) {
-          min = mapping.key;
-        }
-      }
-
-      if (mappings[min] != null) {
-        columnedEvents.add(mappings[min]!);
-        searchEvents.remove(mappings[min]);
-
-        endMinutes = mappings[min]!.getVisibleEndMinutes(calendarDate);
       } else {
-        // No non-overlapping events found, break to avoid infinite loop
+        // Regular single-day event
+        effectiveStartTime = event.startTime!.getTotalMinutes;
+        effectiveEndTime = event.endTime!.getTotalMinutes;
+      }
+
+      // Skip events that don't appear in the visible time range
+      final visibleStart = startHourInMinutes;
+      final visibleEnd = Constants.minutesADay;
+
+      if (effectiveEndTime <= visibleStart ||
+          effectiveStartTime >= visibleEnd) {
+        continue;
+      }
+
+      normalizedEvents.add(_NormalizedEvent<T>(
+        originalEvent: event,
+        effectiveStartTime: effectiveStartTime,
+        effectiveEndTime: effectiveEndTime,
+        isMultiDay: event.isRangingEvent,
+        isFullDay: event.isFullDayEvent,
+      ));
+    }
+
+    return normalizedEvents;
+  }
+
+  /// Creates optimal columns using O(n²) algorithm that prevents overlapping
+  List<List<_NormalizedEvent<T>>> _createOptimalColumns(
+      List<_NormalizedEvent<T>> events) {
+    if (events.isEmpty) return [];
+
+    final columns = <List<_NormalizedEvent<T>>>[];
+
+    for (final event in events) {
+      int targetColumn = -1;
+
+      // Check each existing column to see if this event can fit
+      for (int i = 0; i < columns.length; i++) {
+        if (_canEventFitInColumn(event, columns[i])) {
+          targetColumn = i;
+          break;
+        }
+      }
+
+      // If no available column found, create a new one
+      if (targetColumn == -1) {
+        columns.add([event]);
+      } else {
+        columns[targetColumn].add(event);
+      }
+    }
+
+    return columns;
+  }
+
+  /// Checks if an event can fit in a specific column without overlapping
+  bool _canEventFitInColumn(
+      _NormalizedEvent<T> event, List<_NormalizedEvent<T>> column) {
+    for (final existing in column) {
+      if (_eventsOverlap(event, existing)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Checks if two events overlap based on includeEdges setting
+  bool _eventsOverlap(_NormalizedEvent<T> event1, _NormalizedEvent<T> event2) {
+    if (includeEdges) {
+      // Events overlap if they have any overlapping time (including touching edges)
+      return event1.effectiveStartTime <= event2.effectiveEndTime &&
+          event2.effectiveStartTime <= event1.effectiveEndTime;
+    } else {
+      // Events overlap only if they have actual time overlap (not just touching)
+      return event1.effectiveStartTime < event2.effectiveEndTime &&
+          event2.effectiveStartTime < event1.effectiveEndTime;
+    }
+  }
+
+  /// Converts columns to organized calendar event data with proper width allocation
+  List<OrganizedCalendarEventData<T>> _convertColumnsToOrganizedData(
+    List<List<_NormalizedEvent<T>>> columns,
+    double totalWidth,
+    double height,
+    double heightPerMinute,
+    int startHourInMinutes,
+    DateTime calendarViewDate,
+  ) {
+    final result = <OrganizedCalendarEventData<T>>[];
+    final columnCount = columns.length;
+
+    if (columnCount == 0) return result;
+
+    // Two different strategies based on whether maxWidth is specified
+    if (maxWidth != null) {
+      // Strategy 1: Fixed width columns when maxWidth is specified
+      _processWithFixedMaxWidth(columns, result, totalWidth, height,
+          heightPerMinute, startHourInMinutes, calendarViewDate);
+    } else {
+      // Strategy 2: Dynamic width allocation when maxWidth is NOT specified
+      _processWithDynamicWidth(columns, result, totalWidth, height,
+          heightPerMinute, startHourInMinutes, calendarViewDate);
+    }
+
+    return result;
+  }
+
+  /// Process events with fixed maxWidth for each column
+  /// Process events with fixed maxWidth for each column
+  void _processWithFixedMaxWidth(
+    List<List<_NormalizedEvent<T>>> columns,
+    List<OrganizedCalendarEventData<T>> result,
+    double totalWidth,
+    double height,
+    double heightPerMinute,
+    int startHourInMinutes,
+    DateTime calendarViewDate,
+  ) {
+    final columnCount = columns.length;
+    final baseSlotWidth = totalWidth / columnCount;
+
+    // Calculate actual widths for all events first to avoid gaps
+    final eventWidths = <int, double>{};
+    for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      final column = columns[columnIndex];
+      for (final normalizedEvent in column) {
+        // Calculate dynamic width available to the right
+        final dynamicWidth = _calculateAvailableWidthToRight(
+            normalizedEvent, columns, columnIndex, totalWidth);
+
+        final maxWidthPixels = maxWidth ?? double.maxFinite;
+        eventWidths[normalizedEvent.hashCode] =
+            math.min(dynamicWidth, maxWidthPixels);
+      }
+    }
+
+    // Position events by column
+    for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      final column = columns[columnIndex];
+      final leftPosition = columnIndex * maxWidth!;
+
+      for (final normalizedEvent in column) {
+        final event = normalizedEvent.originalEvent;
+
+        final displayStartTime = math.max(
+            0, normalizedEvent.effectiveStartTime - startHourInMinutes);
+        final displayEndTime = math.min(
+            Constants.minutesADay - startHourInMinutes,
+            normalizedEvent.effectiveEndTime - startHourInMinutes);
+
+        // Use the individual event width rather than column width
+        final actualWidth = eventWidths[normalizedEvent.hashCode]!;
+
+        final top = displayStartTime * heightPerMinute;
+        final visibleMinutes = Constants.minutesADay - startHourInMinutes;
+        final bottom = displayEndTime >= visibleMinutes
+            ? 0.0
+            : height - displayEndTime * heightPerMinute;
+
+        result.add(OrganizedCalendarEventData<T>(
+          left: leftPosition,
+          right: math.max(0.0, totalWidth - leftPosition - actualWidth),
+          top: top,
+          bottom: bottom,
+          startDuration: event.startTime!.copyFromMinutes(displayStartTime),
+          endDuration: event.endTime!.copyFromMinutes(displayEndTime),
+          events: [event],
+          calendarViewDate: calendarViewDate,
+        ));
+      }
+    }
+  }
+
+  /// Process events with dynamic width allocation (stretch to available space)
+  void _processWithDynamicWidth(
+    List<List<_NormalizedEvent<T>>> columns,
+    List<OrganizedCalendarEventData<T>> result,
+    double totalWidth,
+    double height,
+    double heightPerMinute,
+    int startHourInMinutes,
+    DateTime calendarViewDate,
+  ) {
+    final columnCount = columns.length;
+
+    for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      final column = columns[columnIndex];
+
+      for (final normalizedEvent in column) {
+        final event = normalizedEvent.originalEvent;
+
+        final displayStartTime = math.max(
+            0, normalizedEvent.effectiveStartTime - startHourInMinutes);
+        final displayEndTime = math.min(
+            Constants.minutesADay - startHourInMinutes,
+            normalizedEvent.effectiveEndTime - startHourInMinutes);
+
+        // Calculate available width by checking what's to the right
+        final availableWidth = _calculateAvailableWidthToRight(
+            normalizedEvent, columns, columnIndex, totalWidth);
+
+        // Use standard column positioning for left offset
+        final baseSlotWidth = totalWidth / columnCount;
+        final leftOffset = columnIndex * baseSlotWidth;
+
+        // Use the available width (can extend beyond original column)
+        final actualWidth = availableWidth;
+
+        final top = displayStartTime * heightPerMinute;
+        final visibleMinutes = Constants.minutesADay - startHourInMinutes;
+        final bottom = displayEndTime >= visibleMinutes
+            ? 0.0
+            : height - displayEndTime * heightPerMinute;
+
+        result.add(OrganizedCalendarEventData<T>(
+          left: leftOffset,
+          right: math.max(0.0, totalWidth - leftOffset - actualWidth),
+          top: top,
+          bottom: bottom,
+          startDuration: event.startTime!.copyFromMinutes(displayStartTime),
+          endDuration: event.endTime!.copyFromMinutes(displayEndTime),
+          events: [event],
+          calendarViewDate: calendarViewDate,
+        ));
+      }
+    }
+  }
+
+  /// Calculates how much width is available to the right of an event
+  double _calculateAvailableWidthToRight(
+    _NormalizedEvent<T> targetEvent,
+    List<List<_NormalizedEvent<T>>> allColumns,
+    int targetColumnIndex,
+    double totalWidth,
+  ) {
+    final columnCount = allColumns.length;
+    final baseSlotWidth = totalWidth / columnCount;
+    final startPosition = targetColumnIndex * baseSlotWidth;
+
+    // Start with remaining space from current position to end
+    double availableWidth = totalWidth - startPosition;
+
+    // Check each column to the right to see if any events overlap with our target event
+    for (int rightColumnIndex = targetColumnIndex + 1;
+        rightColumnIndex < columnCount;
+        rightColumnIndex++) {
+      final rightColumn = allColumns[rightColumnIndex];
+      bool hasBlockingEvent = false;
+
+      // Check if any event in this right column overlaps with our target event
+      for (final rightEvent in rightColumn) {
+        if (_eventsOverlap(targetEvent, rightEvent)) {
+          hasBlockingEvent = true;
+          break;
+        }
+      }
+
+      if (hasBlockingEvent) {
+        // This column blocks further expansion, limit width to this position
+        final blockingPosition = rightColumnIndex * baseSlotWidth;
+        availableWidth = blockingPosition - startPosition;
         break;
       }
     }
 
-    return columnedEvents;
+    // Ensure minimum width of at least one column
+    return math.max(baseSlotWidth, availableWidth);
   }
 }
 
-class _SideEventConfigs<T extends Object?> {
-  final int columns;
-  final List<CalendarEventData<T>> event;
-  final List<_SideEventConfigs<T>> sideEvents;
+/// Internal class to normalize event data for efficient processing
+class _NormalizedEvent<T extends Object?> {
+  final CalendarEventData<T> originalEvent;
+  final int effectiveStartTime;
+  final int effectiveEndTime;
+  final bool isMultiDay;
+  final bool isFullDay;
 
-  const _SideEventConfigs({
-    this.event = const [],
-    required this.columns,
-    this.sideEvents = const [],
+  const _NormalizedEvent({
+    required this.originalEvent,
+    required this.effectiveStartTime,
+    required this.effectiveEndTime,
+    required this.isMultiDay,
+    required this.isFullDay,
   });
 }

--- a/test/event_arranger_test/side_event_arranger_overlap_test.dart
+++ b/test/event_arranger_test/side_event_arranger_overlap_test.dart
@@ -1,1 +1,501 @@
+// Copyright (c) 2021 Simform Solutions. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
 
+import 'package:calendar_view/calendar_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Constants matching the merge_event_arranger_test conventions.
+const height = 1440.0;
+const width = 600.0; // 600 keeps arithmetic clean (divides evenly by 2, 3, 4)
+const heightPerMinute = 1.0;
+const startHour = 0;
+
+OrganizedCalendarEventData<Object?> _findByTitle(
+  List<OrganizedCalendarEventData<Object?>> results,
+  String title,
+) {
+  return results.firstWhere(
+    (r) => r.events.first.title == title,
+    orElse: () => throw StateError('No result for event "$title"'),
+  );
+}
+
+void main() {
+  final now = DateTime.now().withoutTime;
+
+  // Helper: arrange via SideEventArranger.
+  List<OrganizedCalendarEventData<Object?>> arrange(
+    List<CalendarEventData<Object?>> events, {
+    DateTime? calendarViewDate,
+    double? maxWidth,
+    bool countAdjacentEventsAsOverlapping = false,
+    int startHourOverride = startHour,
+  }) =>
+      SideEventArranger(
+        maxWidth: maxWidth,
+        countAdjacentEventsAsOverlapping: countAdjacentEventsAsOverlapping,
+      ).arrange(
+        events: events,
+        height: height,
+        width: width,
+        heightPerMinute: heightPerMinute,
+        startHour: startHourOverride,
+        calendarViewDate: calendarViewDate ?? now,
+      );
+
+  // ---------------------------------------------------------------------------
+  // Filtering
+  // ---------------------------------------------------------------------------
+  group('SideEventArranger – filtering', () {
+    test('returns empty list for empty input', () {
+      expect(arrange([]), isEmpty);
+    });
+
+    test('filters out events with null startTime', () {
+      final events = [
+        CalendarEventData(
+          title: 'No start',
+          date: now,
+          endTime: now.add(const Duration(hours: 10)),
+        ),
+      ];
+      expect(arrange(events), isEmpty);
+    });
+
+    test('filters out events with null endTime', () {
+      final events = [
+        CalendarEventData(
+          title: 'No end',
+          date: now,
+          startTime: now.add(const Duration(hours: 8)),
+        ),
+      ];
+      expect(arrange(events), isEmpty);
+    });
+
+    test('filters out zero-duration single-day event', () {
+      final events = [
+        CalendarEventData(
+          title: 'Zero',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 10)),
+        ),
+      ];
+      expect(arrange(events), isEmpty);
+    });
+
+    test('includes single-day event ending at midnight (00:00)', () {
+      // endTime of midnight has getTotalMinutes == 0; must be treated as 1440.
+      final events = [
+        CalendarEventData(
+          title: 'Night owl',
+          date: now,
+          startTime: DateTime(now.year, now.month, now.day, 22, 0),
+          endTime: DateTime(now.year, now.month, now.day, 0, 0), // midnight
+        ),
+      ];
+      final results = arrange(events);
+      expect(results, hasLength(1));
+      // Event starts at 22:00 (1320 min) and extends to end of day.
+      expect(results.first.top, 1320.0);
+      expect(results.first.bottom, 0.0); // reaches the very bottom
+    });
+
+    test('filters out event whose effective range is entirely before startHour',
+        () {
+      // startHour=8, event is 06:00–07:00 → should not appear.
+      final events = [
+        CalendarEventData(
+          title: 'Too early',
+          date: now,
+          startTime: now.add(const Duration(hours: 6)),
+          endTime: now.add(const Duration(hours: 7)),
+        ),
+      ];
+      expect(arrange(events, startHourOverride: 8), isEmpty);
+    });
+
+    test('includes event that straddles the startHour boundary', () {
+      // startHour=8, event is 07:00–09:00 → partially visible.
+      final events = [
+        CalendarEventData(
+          title: 'Straddles',
+          date: now,
+          startTime: now.add(const Duration(hours: 7)),
+          endTime: now.add(const Duration(hours: 9)),
+        ),
+      ];
+      expect(arrange(events, startHourOverride: 8), hasLength(1));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multi-day event normalization
+  // ---------------------------------------------------------------------------
+  group('SideEventArranger – multi-day normalization', () {
+    final yesterday = now.subtract(const Duration(days: 1));
+    final tomorrow = now.add(const Duration(days: 1));
+
+    // A 3-day event (yesterday → tomorrow); today is the middle day.
+    CalendarEventData<Object?> threeDayEvent() => CalendarEventData(
+          title: 'Three-day',
+          date: yesterday,
+          endDate: tomorrow,
+          // Only hours/minutes are used; the date component is ignored.
+          startTime:
+              DateTime(yesterday.year, yesterday.month, yesterday.day, 10, 0),
+          endTime:
+              DateTime(yesterday.year, yesterday.month, yesterday.day, 15, 0),
+        );
+
+    test('middle day: spans the full day (top=0, bottom=0)', () {
+      final results = arrange([threeDayEvent()], calendarViewDate: now);
+      expect(results, hasLength(1));
+      expect(results.first.top, 0.0);
+      expect(results.first.bottom, 0.0);
+    });
+
+    test('start day: starts at event startTime, ends at bottom of day', () {
+      final results = arrange([threeDayEvent()], calendarViewDate: yesterday);
+      expect(results, hasLength(1));
+      expect(results.first.top, 600.0); // 10:00 = 600 min @ 1 px/min
+      expect(results.first.bottom, 0.0); // extends to end of day
+    });
+
+    test('end day: starts at top of day, ends at event endTime', () {
+      final results = arrange([threeDayEvent()], calendarViewDate: tomorrow);
+      expect(results, hasLength(1));
+      expect(results.first.top, 0.0);
+      // bottom = height – endMinutes × heightPerMinute = 1440 – 900 = 540
+      expect(results.first.bottom, 540.0);
+    });
+
+    test('end day with midnight endTime: treated as end-of-day', () {
+      // Event runs from yesterday to today; ends at 00:00 today.
+      final event = CalendarEventData(
+        title: 'Ends midnight',
+        date: yesterday,
+        endDate: now,
+        startTime:
+            DateTime(yesterday.year, yesterday.month, yesterday.day, 20, 0),
+        endTime: DateTime(
+            yesterday.year, yesterday.month, yesterday.day, 0, 0), // midnight
+      );
+      final results = arrange([event], calendarViewDate: now);
+      expect(results, hasLength(1));
+      // Effective end = 1440 → bottom = 0.0 (reaches the very bottom).
+      expect(results.first.top, 0.0);
+      expect(results.first.bottom, 0.0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Column placement / overlap detection
+  // ---------------------------------------------------------------------------
+  group('SideEventArranger – column placement', () {
+    test('single event gets full width', () {
+      final events = [
+        CalendarEventData(
+          title: 'Solo',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+      ];
+      final results = arrange(events);
+      expect(results, hasLength(1));
+      expect(results.first.left, 0.0);
+      expect(results.first.right, 0.0);
+    });
+
+    test('two non-overlapping events share one column, each gets full width',
+        () {
+      final events = [
+        CalendarEventData(
+          title: 'A',
+          date: now,
+          startTime: now.add(const Duration(hours: 8)),
+          endTime: now.add(const Duration(hours: 10)),
+        ),
+        CalendarEventData(
+          title: 'B',
+          date: now,
+          startTime: now.add(const Duration(hours: 12)),
+          endTime: now.add(const Duration(hours: 14)),
+        ),
+      ];
+      final results = arrange(events);
+      expect(results, hasLength(2));
+      for (final r in results) {
+        expect(r.left, 0.0);
+        expect(r.right, 0.0);
+      }
+    });
+
+    test('two overlapping events go into two columns each with half width', () {
+      // width=600 → each column = 300.
+      final events = [
+        CalendarEventData(
+          title: 'A',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+        CalendarEventData(
+          title: 'B',
+          date: now,
+          startTime: now.add(const Duration(hours: 11)),
+          endTime: now.add(const Duration(hours: 13)),
+        ),
+      ];
+      final results = arrange(events);
+      expect(results, hasLength(2));
+      final a = _findByTitle(results, 'A');
+      final b = _findByTitle(results, 'B');
+      expect(a.left, 0.0);
+      expect(a.right, 300.0);
+      expect(b.left, 300.0);
+      expect(b.right, 0.0);
+    });
+
+    test('three mutually overlapping events each go into their own column', () {
+      final events = [
+        CalendarEventData(
+          title: 'A',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+        CalendarEventData(
+          title: 'B',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+        CalendarEventData(
+          title: 'C',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+      ];
+      final results = arrange(events);
+      expect(results, hasLength(3));
+      final lefts = results.map((r) => r.left).toSet();
+      expect(lefts, hasLength(3)); // three distinct horizontal positions
+    });
+
+    test('time positions (top/bottom) are computed correctly', () {
+      final events = [
+        CalendarEventData(
+          title: 'Timed',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+      ];
+      final results = arrange(events);
+      expect(results.first.top, 600.0); // 10 * 60 * 1.0 px/min
+      expect(results.first.bottom, 720.0); // 1440 – (12 * 60) = 720
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // countAdjacentEventsAsOverlapping
+  // ---------------------------------------------------------------------------
+  group('SideEventArranger – countAdjacentEventsAsOverlapping', () {
+    final touchingEvents = [
+      CalendarEventData(
+        title: 'A',
+        date: now,
+        startTime: now.add(const Duration(hours: 10)),
+        endTime: now.add(const Duration(hours: 12)),
+      ),
+      CalendarEventData(
+        title: 'B',
+        date: now,
+        startTime: now.add(const Duration(hours: 12)),
+        endTime: now.add(const Duration(hours: 14)),
+      ),
+    ];
+
+    test('false (default): adjacent events share a column', () {
+      final results =
+          arrange(touchingEvents, countAdjacentEventsAsOverlapping: false);
+      expect(results, hasLength(2));
+      // Only one distinct left position → one column.
+      expect(results.map((r) => r.left).toSet(), hasLength(1));
+    });
+
+    test('true: adjacent events are considered overlapping → two columns', () {
+      final results =
+          arrange(touchingEvents, countAdjacentEventsAsOverlapping: true);
+      expect(results, hasLength(2));
+      expect(results.map((r) => r.left).toSet(), hasLength(2));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dynamic width expansion (no maxWidth)
+  // ---------------------------------------------------------------------------
+  group('SideEventArranger – dynamic width expansion', () {
+    test('event without a right-column blocker expands to full available width',
+        () {
+      // Columns assigned (sorted by start time):
+      //   Col 0: X (09:00–11:00), Z (13:00–14:00)
+      //   Col 1: Y (10:00–12:00)
+      //
+      // X overlaps Y   → X is capped at half width (300).
+      // Z does not overlap Y → Z should expand to full width (600).
+      final events = [
+        CalendarEventData(
+          title: 'X',
+          date: now,
+          startTime: now.add(const Duration(hours: 9)),
+          endTime: now.add(const Duration(hours: 11)),
+        ),
+        CalendarEventData(
+          title: 'Y',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+        CalendarEventData(
+          title: 'Z',
+          date: now,
+          startTime: now.add(const Duration(hours: 13)),
+          endTime: now.add(const Duration(hours: 14)),
+        ),
+      ];
+      final results = arrange(events);
+      expect(results, hasLength(3));
+
+      final x = _findByTitle(results, 'X');
+      final y = _findByTitle(results, 'Y');
+      final z = _findByTitle(results, 'Z');
+
+      // X is blocked by Y → confined to half width.
+      expect(x.left, 0.0);
+      expect(x.right, 300.0);
+
+      // Y occupies column 1 with no further columns to its right.
+      expect(y.left, 300.0);
+      expect(y.right, 0.0);
+
+      // Z is in column 0 but never overlaps anything in column 1 → full width.
+      expect(z.left, 0.0);
+      expect(z.right, 0.0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fixed maxWidth
+  // ---------------------------------------------------------------------------
+  group('SideEventArranger – fixed maxWidth', () {
+    test('single event is constrained to maxWidth', () {
+      const max = 200.0;
+      final events = [
+        CalendarEventData(
+          title: 'Solo',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+      ];
+      final results = arrange(events, maxWidth: max);
+      expect(results, hasLength(1));
+      final renderedWidth = width - results.first.left - results.first.right;
+      expect(renderedWidth, max);
+    });
+
+    test('event uses dynamic slot width when maxWidth exceeds it', () {
+      // width=600, 2 overlapping events → baseSlotWidth=300.
+      // maxWidth=500 > 300, so each event gets 300.
+      const max = 500.0;
+      final events = [
+        CalendarEventData(
+          title: 'A',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+        CalendarEventData(
+          title: 'B',
+          date: now,
+          startTime: now.add(const Duration(hours: 11)),
+          endTime: now.add(const Duration(hours: 13)),
+        ),
+      ];
+      final results = arrange(events, maxWidth: max);
+      for (final r in results) {
+        final renderedWidth = width - r.left - r.right;
+        expect(renderedWidth, closeTo(300.0, 0.01));
+      }
+    });
+
+    test(
+        'two overlapping events with maxWidth < slot: each gets maxWidth,'
+        ' columns advance by maxWidth', () {
+      // width=600, 2 overlapping events → baseSlotWidth=300.
+      // maxWidth=200 < 300 → each event gets 200.
+      // Columns: A at left=0, B at left=200.
+      const max = 200.0;
+      final events = [
+        CalendarEventData(
+          title: 'A',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+        CalendarEventData(
+          title: 'B',
+          date: now,
+          startTime: now.add(const Duration(hours: 11)),
+          endTime: now.add(const Duration(hours: 13)),
+        ),
+      ];
+      final results = arrange(events, maxWidth: max);
+      expect(results, hasLength(2));
+
+      final a = _findByTitle(results, 'A');
+      final b = _findByTitle(results, 'B');
+
+      expect(a.left, closeTo(0.0, 0.01));
+      expect(width - a.left - a.right, closeTo(max, 0.01));
+
+      expect(b.left, closeTo(max, 0.01));
+      expect(width - b.left - b.right, closeTo(max, 0.01));
+    });
+
+    test('no event visually overflows into the next column', () {
+      // 3 mutually overlapping events, maxWidth=150.
+      // width=600 → baseSlotWidth=200; min(200,150)=150 per column.
+      const max = 150.0;
+      final events = List.generate(
+        3,
+        (i) => CalendarEventData(
+          title: 'E$i',
+          date: now,
+          startTime: now.add(const Duration(hours: 10)),
+          endTime: now.add(const Duration(hours: 12)),
+        ),
+      );
+      final results = arrange(events, maxWidth: max);
+      expect(results, hasLength(3));
+
+      final sorted = results.toList()..sort((a, b) => a.left.compareTo(b.left));
+      for (int i = 0; i < sorted.length - 1; i++) {
+        final rightEdge =
+            sorted[i].left + (width - sorted[i].left - sorted[i].right);
+        expect(
+          rightEdge,
+          lessThanOrEqualTo(sorted[i + 1].left + 0.01),
+          reason:
+              'Event at left=${sorted[i].left} overflows into event at left=${sorted[i + 1].left}',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description

This PR rewrites `SideEventArranger` with a new column-based event layout engine focused on improving maintainability, correctness, scalability, and width allocation behavior for overlapping events.

### What changed

The previous implementation used a recursive event extraction and arrangement algorithm. While functional, the approach became increasingly difficult to maintain and reason about as support for multi-day events, overlap edge cases, and visibility calculations was added.

This PR replaces that implementation with a normalized column-based layout system that:

* Normalizes events before layout calculation
* Uses a deterministic column-packing algorithm
* Centralizes overlap detection logic
* Improves multi-day and spanning event handling
* Reduces recursive recomputation and repeated overlap scanning
* Improves runtime complexity and maintainability
* Dynamically expands events to use available horizontal space when possible

### Behavioral changes and breaking changes

The layout behavior of overlapping events has changed in some scenarios.

Previously, overlapping events were recursively constrained to progressively smaller widths. The new implementation allows events to expand horizontally until blocked by overlapping events in adjacent columns.

#### Before

```dart
SideEventArranger(
  includeEdges: true,
)
```

Events remained constrained to their recursively assigned width even if adjacent space later became available.

#### After

```dart
SideEventArranger(
  countAdjacentEventsAsOverlapping: true,
)
```

Events can dynamically expand to use additional available width, reducing unused horizontal gaps and improving readability.

## Checklist

* [x] The title of my PR starts with a Conventional Commit prefix (fix:, feat:, docs: etc).
* [x] I have followed the Contributor Guide when preparing my PR.
* [ ] I have updated/added tests for ALL new/updated/fixed functionality.
* [x] I have updated/added relevant documentation in docs and added dartdoc comments with ///.
* [ ] I have updated/added relevant examples in examples or docs.

## Breaking Change?

* [x] Yes, this PR is a breaking change.
* [ ] No, this PR is not a breaking change.


## Related Issues
N/A