### PR TITLE
fix: timeLineBuilder not returning 0:00 in Day and Week views

### DIFF
--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -268,7 +268,7 @@ class _TimeLineState extends State<TimeLine> {
       ),
       child: Stack(
         children: [
-          for (int i = widget.startHour + 1; i <= widget.endHour; i++)
+          for (int i = widget.startHour; i < widget.endHour; i++)
             _timelinePositioned(
               topPosition: widget.hourHeight * (i - widget.startHour) -
                   widget.timeLineOffset,
@@ -278,7 +278,7 @@ class _TimeLineState extends State<TimeLine> {
               hour: i,
             ),
           if (widget.showHalfHours)
-            for (int i = widget.startHour; i <= widget.endHour; i++)
+            for (int i = widget.startHour; i < widget.endHour; i++)
               _timelinePositioned(
                 topPosition: widget.hourHeight * (i - widget.startHour) -
                     widget.timeLineOffset +
@@ -290,7 +290,7 @@ class _TimeLineState extends State<TimeLine> {
                 minutes: 30,
               ),
           if (widget.showQuarterHours)
-            for (int i = widget.startHour; i <= widget.endHour; i++) ...[
+            for (int i = widget.startHour; i < widget.endHour; i++) ...[
               /// this is for 15 minutes
               _timelinePositioned(
                 topPosition: widget.hourHeight * (i - widget.startHour) -

--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -338,7 +338,7 @@ class _TimeLineState extends State<TimeLine> {
       hour,
       minutes,
     );
-
+    print("_timelinePositioned currentDateTime:$currentDateTime dateTime:$dateTime");
     return Visibility(
       visible: !((_currentTime.minute >= 45 && _currentTime.hour == hour - 1) ||
               (_currentTime.minute <= 15 && _currentTime.hour == hour)) ||

--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -338,7 +338,6 @@ class _TimeLineState extends State<TimeLine> {
       hour,
       minutes,
     );
-    print("_timelinePositioned currentDateTime:$currentDateTime dateTime:$dateTime");
     return Visibility(
       visible: !((_currentTime.minute >= 45 && _currentTime.hour == hour - 1) ||
               (_currentTime.minute <= 15 && _currentTime.hour == hour)) ||

--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -268,7 +268,7 @@ class _TimeLineState extends State<TimeLine> {
       ),
       child: Stack(
         children: [
-          for (int i = widget.startHour + 1; i < widget.endHour; i++)
+          for (int i = widget.startHour + 1; i <= widget.endHour; i++)
             _timelinePositioned(
               topPosition: widget.hourHeight * (i - widget.startHour) -
                   widget.timeLineOffset,
@@ -278,7 +278,7 @@ class _TimeLineState extends State<TimeLine> {
               hour: i,
             ),
           if (widget.showHalfHours)
-            for (int i = widget.startHour; i < widget.endHour; i++)
+            for (int i = widget.startHour; i <= widget.endHour; i++)
               _timelinePositioned(
                 topPosition: widget.hourHeight * (i - widget.startHour) -
                     widget.timeLineOffset +
@@ -290,7 +290,7 @@ class _TimeLineState extends State<TimeLine> {
                 minutes: 30,
               ),
           if (widget.showQuarterHours)
-            for (int i = widget.startHour; i < widget.endHour; i++) ...[
+            for (int i = widget.startHour; i <= widget.endHour; i++) ...[
               /// this is for 15 minutes
               _timelinePositioned(
                 topPosition: widget.hourHeight * (i - widget.startHour) -


### PR DESCRIPTION
# Description
Fix the issue where timeLineBuilder does not return 0:00 in Day view and Week view

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

<!-- If this PR fixes a specific issue, uncomment and update the line below -->
<!-- Closes #issue_number -->

Fixes an issue where timeLineBuilder does not return 0:00 time slot in Day view and Week view.