### PR TITLE
fix: slow onTap response

### DIFF
--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -439,9 +439,15 @@ class EventGenerator<T extends Object?> extends StatelessWidget {
         left: events[index].left,
         right: events[index].right,
         child: GestureDetector(
-          onLongPress: () => onTileLongTap?.call(events[index].events, date),
-          onTap: () => onTileTap?.call(events[index].events, date),
-          onDoubleTap: () => onTileDoubleTap?.call(events[index].events, date),
+          onLongPress: onTileLongTap != null
+              ? () => onTileLongTap?.call(events[index].events, date)
+              : null,
+          onTap: onTileTap != null
+              ? () => onTileTap?.call(events[index].events, date)
+              : null,
+          onDoubleTap: onTileDoubleTap != null
+              ? () => onTileDoubleTap?.call(events[index].events, date)
+              : null,
           child: Builder(builder: (context) {
             if (scrollNotifier.shouldScroll &&
                 events[index]


### PR DESCRIPTION
# Description
When pressing a tile in the week view, we currently always wait for some time to distinguish `onTap` from `onLongPress`, even if the `onLongPress` callback is null. This adds some noticable delay to the user response even if t would not be needed.
This PR passes null to the GestureDetector for all callbacks that are null.


## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
None

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org