### PR TITLE
fix: consider showOnlyToday param in week view page

### DIFF
--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -38,6 +38,14 @@ class LiveTimeIndicator extends StatefulWidget {
   /// Flag to show only today's events.
   final bool onlyShowToday;
 
+  /// The specific calendar date this indicator is rendered for (week/multi-day
+  /// column). When provided, the indicator hides itself whenever the current
+  /// time (from [LiveTimeIndicatorSettings.currentTimeProvider] or
+  /// [DateTime.now]) falls on a different day. This check runs inside the
+  /// widget's own timer so it responds to midnight rollovers and custom time
+  /// providers without requiring the parent to rebuild.
+  final DateTime? date;
+
   /// Widget to display tile line according to current time.
   const LiveTimeIndicator(
       {Key? key,
@@ -48,7 +56,8 @@ class LiveTimeIndicator extends StatefulWidget {
       required this.heightPerMinute,
       required this.startHour,
       this.endHour = Constants.hoursADay,
-      this.onlyShowToday = false})
+      this.onlyShowToday = false,
+      this.date})
       : super(key: key);
 
   @override
@@ -107,6 +116,15 @@ class _LiveTimeIndicatorState extends State<LiveTimeIndicator> {
         ? PackageStrings.currentLocale.am
         : PackageStrings.currentLocale.pm;
     final currentDateTime = _getCurrentDateTime();
+
+    // When a specific column date is provided, hide the indicator if the
+    // provider's current day no longer matches (handles custom timezones and
+    // midnight rollovers without requiring the parent to rebuild).
+    if (widget.date != null &&
+        !DateUtils.isSameDay(widget.date, currentDateTime)) {
+      return SizedBox.shrink();
+    }
+
     final localizedHour =
         PackageStrings.localizeNumber(int.tryParse(currentHour) ?? 0);
     final localizedMinute =

--- a/lib/src/multi_day_view/_internal_multi_day_view_page.dart
+++ b/lib/src/multi_day_view/_internal_multi_day_view_page.dart
@@ -493,22 +493,20 @@ class _InternalMultiDayViewPageState<T extends Object?>
                                             0 &&
                                         widget.liveTimeIndicatorSettings
                                             .onlyShowToday)
-                                      if (DateUtils.isSameDay(
-                                          widget.dates[index], DateTime.now()))
-                                        LiveTimeIndicator(
-                                          liveTimeIndicatorSettings:
-                                              widget.liveTimeIndicatorSettings,
-                                          width: widget.width,
-                                          height: widget.height,
-                                          heightPerMinute:
-                                              widget.heightPerMinute,
-                                          timeLineWidth: widget.timeLineWidth,
-                                          startHour: widget.startHour,
-                                          endHour: widget.endHour,
-                                          onlyShowToday: widget
-                                              .liveTimeIndicatorSettings
-                                              .onlyShowToday,
-                                        ),
+                                      LiveTimeIndicator(
+                                        liveTimeIndicatorSettings:
+                                            widget.liveTimeIndicatorSettings,
+                                        width: widget.width,
+                                        height: widget.height,
+                                        heightPerMinute: widget.heightPerMinute,
+                                        timeLineWidth: widget.timeLineWidth,
+                                        startHour: widget.startHour,
+                                        endHour: widget.endHour,
+                                        onlyShowToday: widget
+                                            .liveTimeIndicatorSettings
+                                            .onlyShowToday,
+                                        date: widget.dates[index],
+                                      ),
                                   ],
                                 ),
                               ),

--- a/lib/src/multi_day_view/_internal_multi_day_view_page.dart
+++ b/lib/src/multi_day_view/_internal_multi_day_view_page.dart
@@ -487,8 +487,7 @@ class _InternalMultiDayViewPageState<T extends Object?>
                                       heightPerMinute: widget.heightPerMinute,
                                       endHour: widget.endHour,
                                     ),
-                                    if (widget.showLiveLine &&
-                                        widget.liveTimeIndicatorSettings
+                                    if (widget.liveTimeIndicatorSettings
                                                 .height >
                                             0 &&
                                         widget.liveTimeIndicatorSettings

--- a/lib/src/multi_day_view/_internal_multi_day_view_page.dart
+++ b/lib/src/multi_day_view/_internal_multi_day_view_page.dart
@@ -505,7 +505,7 @@ class _InternalMultiDayViewPageState<T extends Object?>
                                         onlyShowToday: widget
                                             .liveTimeIndicatorSettings
                                             .onlyShowToday,
-                                        date: widget.dates[index],
+                                        date: filteredDates[index],
                                       ),
                                   ],
                                 ),

--- a/lib/src/multi_day_view/_internal_multi_day_view_page.dart
+++ b/lib/src/multi_day_view/_internal_multi_day_view_page.dart
@@ -539,6 +539,20 @@ class _InternalMultiDayViewPageState<T extends Object?>
                           offset: widget.liveTimeIndicatorSettings.offset,
                           onlyShowToday:
                               widget.liveTimeIndicatorSettings.onlyShowToday,
+                          timeStringBuilder: widget
+                              .liveTimeIndicatorSettings.timeStringBuilder,
+                          showBullet:
+                              widget.liveTimeIndicatorSettings.showBullet,
+                          showTime: widget.liveTimeIndicatorSettings.showTime,
+                          showTimeBackgroundView: widget
+                              .liveTimeIndicatorSettings.showTimeBackgroundView,
+                          bulletRadius:
+                              widget.liveTimeIndicatorSettings.bulletRadius,
+                          timeBackgroundViewWidth: widget
+                              .liveTimeIndicatorSettings
+                              .timeBackgroundViewWidth,
+                          currentTimeProvider: widget
+                              .liveTimeIndicatorSettings.currentTimeProvider,
                         ),
                         width: widget.width,
                         height: widget.height,

--- a/lib/src/multi_day_view/multi_day_view.dart
+++ b/lib/src/multi_day_view/multi_day_view.dart
@@ -1089,8 +1089,11 @@ class MultiDayViewState<T extends Object?> extends State<MultiDayView<T>> {
 
   /// check if any dates contains current date or not.
   /// Returns true if it does else false.
-  bool _showLiveTimeIndicator(List<DateTime> dates) =>
-      dates.any((date) => date.compareWithoutTime(DateTime.now()));
+  bool _showLiveTimeIndicator(List<DateTime> dates) {
+    final now = _liveTimeIndicatorSettings.currentTimeProvider?.call() ??
+        DateTime.now();
+    return dates.any((date) => date.compareWithoutTime(now));
+  }
 
   /// Listener for every week page ScrollController
   void _scrollPageListener(ScrollController controller) {

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -491,6 +491,28 @@ class _InternalWeekViewPageState<T extends Object?>
                                       heightPerMinute: widget.heightPerMinute,
                                       endHour: widget.endHour,
                                     ),
+                                    if (widget.showLiveLine &&
+                                        widget.liveTimeIndicatorSettings
+                                                .height >
+                                            0 &&
+                                        widget.liveTimeIndicatorSettings
+                                            .onlyShowToday)
+                                      if (DateUtils.isSameDay(
+                                          filteredDates[index], DateTime.now()))
+                                        LiveTimeIndicator(
+                                          liveTimeIndicatorSettings:
+                                              widget.liveTimeIndicatorSettings,
+                                          width: widget.width,
+                                          height: widget.height,
+                                          heightPerMinute:
+                                              widget.heightPerMinute,
+                                          timeLineWidth: widget.timeLineWidth,
+                                          startHour: widget.startHour,
+                                          endHour: widget.endHour,
+                                          onlyShowToday: widget
+                                              .liveTimeIndicatorSettings
+                                              .onlyShowToday,
+                                        ),
                                   ],
                                 ),
                               ),
@@ -514,7 +536,8 @@ class _InternalWeekViewPageState<T extends Object?>
                       onTimestampTap: widget.onTimestampTap,
                     ),
                     if (widget.showLiveLine &&
-                        widget.liveTimeIndicatorSettings.height > 0)
+                        widget.liveTimeIndicatorSettings.height > 0 &&
+                        !widget.liveTimeIndicatorSettings.onlyShowToday)
                       LiveTimeIndicator(
                         liveTimeIndicatorSettings:
                             widget.liveTimeIndicatorSettings,

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -491,8 +491,7 @@ class _InternalWeekViewPageState<T extends Object?>
                                       heightPerMinute: widget.heightPerMinute,
                                       endHour: widget.endHour,
                                     ),
-                                    if (widget.showLiveLine &&
-                                        widget.liveTimeIndicatorSettings
+                                    if (widget.liveTimeIndicatorSettings
                                                 .height >
                                             0 &&
                                         widget.liveTimeIndicatorSettings

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -497,22 +497,20 @@ class _InternalWeekViewPageState<T extends Object?>
                                             0 &&
                                         widget.liveTimeIndicatorSettings
                                             .onlyShowToday)
-                                      if (DateUtils.isSameDay(
-                                          filteredDates[index], DateTime.now()))
-                                        LiveTimeIndicator(
-                                          liveTimeIndicatorSettings:
-                                              widget.liveTimeIndicatorSettings,
-                                          width: widget.width,
-                                          height: widget.height,
-                                          heightPerMinute:
-                                              widget.heightPerMinute,
-                                          timeLineWidth: widget.timeLineWidth,
-                                          startHour: widget.startHour,
-                                          endHour: widget.endHour,
-                                          onlyShowToday: widget
-                                              .liveTimeIndicatorSettings
-                                              .onlyShowToday,
-                                        ),
+                                      LiveTimeIndicator(
+                                        liveTimeIndicatorSettings:
+                                            widget.liveTimeIndicatorSettings,
+                                        width: widget.width,
+                                        height: widget.height,
+                                        heightPerMinute: widget.heightPerMinute,
+                                        timeLineWidth: widget.timeLineWidth,
+                                        startHour: widget.startHour,
+                                        endHour: widget.endHour,
+                                        onlyShowToday: widget
+                                            .liveTimeIndicatorSettings
+                                            .onlyShowToday,
+                                        date: filteredDates[index],
+                                      ),
                                   ],
                                 ),
                               ),

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -1060,8 +1060,11 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
 
   /// check if any dates contains current date or not.
   /// Returns true if it does else false.
-  bool _showLiveTimeIndicator(List<DateTime> dates) =>
-      dates.any((date) => date.compareWithoutTime(DateTime.now()));
+  bool _showLiveTimeIndicator(List<DateTime> dates) {
+    final now = _liveTimeIndicatorSettings.currentTimeProvider?.call() ??
+        DateTime.now();
+    return dates.any((date) => date.compareWithoutTime(now));
+  }
 
   /// Listener for every week page ScrollController
   void _scrollPageListener(ScrollController controller) {


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


Even if the `onlyShowToday` is set to `true` for the `LiveTimeIndicator` in `WeekView`, the indicator is still being drawn for the whole week.

It appears that `InternalWeekViewPage` is ignoring the `onlyShowToday` parameter of `LiveTimeIndicator`. I simply copied the exact same logic that is used in `InternalMultiDayViewPage` to display the indicator for either the whole week or just today.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

Fixes: #518

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org