### PR TITLE
feat: Fixes issue #401 ✨Add onDateLongPressMoveUpdate callback to MonthView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `pageDate` parameter for timeline label customization with current timestamp fallback. [#527](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/527)
 - [BREAKING] Added `selectedDate` control to `MonthView` for external date management. [#233](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/233)
 - Added `showMidnightHour` parameter in `DayView` and `WeekView` to control whether the `00:00` label is shown on the timeline. Default is `false`. [#492](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/492)
+- Added `onDateLongPressMoveUpdate` callback to `MonthView`, along with `MonthView.multiDateSelectionRange`, `MonthView.multiDateSelectionColor`, and `FilledCell.multipleDateSelectionColor` for multi-date selection customization.  [#401](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/401)
 
 # [2.0.0 - 17 Mar 2026](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/2.0.0)
 

--- a/example/lib/widgets/month_view_widget.dart
+++ b/example/lib/widgets/month_view_widget.dart
@@ -1,5 +1,6 @@
 import 'package:calendar_view/calendar_view.dart';
 import 'package:example/extension.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../pages/event_details_page.dart';
@@ -16,6 +17,8 @@ class MonthViewWidget extends StatefulWidget {
 
 class _MonthViewWidgetState extends State<MonthViewWidget> {
   late DateTime _selectedDate;
+  DateTime? _multiSelectionStartDate;
+  Set<DateTime> _multiSelectedDateRange = <DateTime>{};
 
   @override
   void initState() {
@@ -26,54 +29,142 @@ class _MonthViewWidgetState extends State<MonthViewWidget> {
   @override
   Widget build(BuildContext context) {
     final translate = context.translate;
-    return MonthView(
-      key: widget.state,
-      width: widget.width,
-      selectedDate: _selectedDate,
-      monthViewThemeSettings: MonthViewThemeSettings(
-        cellsInMonthHighlightColor: Colors.blue,
-        selectedHighlightColor: Colors.deepOrange,
-        selectedTitleColor: Colors.white,
-        selectedHighlightRadius: 12,
-      ),
-      monthViewStyle: MonthViewStyle(
-        startDay: WeekDays.friday,
-        useAvailableVerticalSpace: true,
-        hideDaysNotInMonth: true,
-        // Define the range of months to display
-        maxMonth: DateTime(2027, 12, 31),
-        minMonth: DateTime(2020, 1, 1),
-        pagePhysics: NeverScrollableScrollPhysics(),
-      ),
-      monthViewBuilders: MonthViewBuilders(
-        //When user tries to scroll beyond the max month or min month
-        // these callbacks will be triggered.
-        onHasReachedEnd: (date, page) {
-          SnackBar snackBar = SnackBar(
-            content: Text(translate.reachedTheEndPage),
-          );
-          ScaffoldMessenger.of(context).showSnackBar(snackBar);
-        },
-        onHasReachedStart: (date, page) {
-          SnackBar snackBar = SnackBar(
-            content: Text(translate.reachedTheStartPage),
-          );
-          ScaffoldMessenger.of(context).showSnackBar(snackBar);
-        },
-        onCellTap: (events, date) =>
-            setState(() => _selectedDate = date.withoutTime),
-        onEventTap: (event, date) {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => DetailsPage(event: event, date: date),
+    return Stack(
+      children: [
+        MonthView(
+          key: widget.state,
+          width: widget.width,
+          selectedDate: _selectedDate,
+          multiDateSelectionRange: _multiSelectedDateRange,
+          multiDateSelectionColor: Colors.blue.withValues(alpha: 0.1),
+          monthViewThemeSettings: MonthViewThemeSettings(
+            cellsInMonthHighlightColor: Colors.blue,
+            selectedHighlightColor: Colors.deepOrange,
+            selectedTitleColor: Colors.white,
+            selectedHighlightRadius: 12,
+          ),
+          monthViewStyle: MonthViewStyle(
+            startDay: WeekDays.friday,
+            useAvailableVerticalSpace: true,
+            hideDaysNotInMonth: true,
+            // Define the range of months to display
+            maxMonth: DateTime(2027, 12, 31),
+            minMonth: DateTime(2020, 1, 1),
+            pagePhysics: NeverScrollableScrollPhysics(),
+          ),
+          monthViewBuilders: MonthViewBuilders(
+            //When user tries to scroll beyond the max month or min month
+            // these callbacks will be triggered.
+            onHasReachedEnd: (date, page) {
+              context.showSnackBarWithText(translate.reachedTheEndPage);
+            },
+            onHasReachedStart: (date, page) {
+              context.showSnackBarWithText(translate.reachedTheStartPage);
+            },
+            onDateLongPress: (date) {
+              _multiSelectionStartDate = _normalizeDate(date);
+              _setSelectedRange(
+                _multiSelectionStartDate!,
+                _multiSelectionStartDate!,
+              );
+              context.showSnackBarWithText(
+                "Multiple dates selection started: " +
+                    date.dateToStringWithFormat(format: 'y-MM-dd'),
+              );
+            },
+            onDateLongPressMoveUpdate: (date, details) {
+              final startDate = _multiSelectionStartDate;
+              if (startDate == null) return;
+              _setSelectedRange(startDate, _normalizeDate(date));
+            },
+            onCellTap: (events, date) {
+              setState(() => _selectedDate = date.withoutTime);
+              final normalizedDate = _normalizeDate(date);
+              if (_multiSelectedDateRange.isNotEmpty) {
+                if (_multiSelectedDateRange.contains(normalizedDate)) {
+                  context.showSnackBarWithText(
+                    '${_multiSelectedDateRange.length} date${_multiSelectedDateRange.length == 1 ? '' : 's'} selected',
+                  );
+                } else {
+                  // Tapping any non-selected date clears the selection.
+                  setState(() {
+                    _multiSelectionStartDate = null;
+                    _multiSelectedDateRange = <DateTime>{};
+                  });
+                }
+                return;
+              }
+              context.showSnackBarWithText(
+                "Tapped " + date.dateToStringWithFormat(format: 'y-MM-dd'),
+              );
+            },
+            onEventTap: (event, date) {
+              // If a selection is active, any event tap clears it instead of
+              // opening the event.
+              if (_multiSelectedDateRange.isNotEmpty) {
+                setState(() {
+                  _multiSelectionStartDate = null;
+                  _multiSelectedDateRange = <DateTime>{};
+                });
+                return;
+              }
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => DetailsPage(event: event, date: date),
+                ),
+              );
+            },
+            onEventLongTap: (event, date) =>
+                context.showSnackBarWithText("on LongTap"),
+          ),
+        ),
+        // Cancel button - rolls out from right center
+        AnimatedPositioned(
+          duration: const Duration(milliseconds: 500),
+          curve: Curves.easeInOut,
+          right: _multiSelectedDateRange.isNotEmpty ? 10 : -80,
+          top: 0,
+          bottom: 0,
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: FloatingActionButton.small(
+              onPressed: _clearSelection,
+              child: Icon(Icons.close, color: context.appColors.onPrimary),
             ),
-          );
-        },
-        onEventLongTap: (event, date) {
-          SnackBar snackBar = SnackBar(content: Text("on LongTap"));
-          ScaffoldMessenger.of(context).showSnackBar(snackBar);
-        },
-      ),
+          ),
+        ),
+      ],
     );
+  }
+
+  DateTime _normalizeDate(DateTime date) =>
+      DateTime(date.year, date.month, date.day);
+
+  void _setSelectedRange(DateTime start, DateTime end) {
+    final range = <DateTime>{};
+    final first = start.isBefore(end) ? start : end;
+    final last = start.isBefore(end) ? end : start;
+
+    for (
+      var date = first;
+      !date.isAfter(last);
+      date = date.add(const Duration(days: 1))
+    ) {
+      range.add(_normalizeDate(date));
+    }
+
+    if (setEquals(range, _multiSelectedDateRange)) return;
+
+    setState(() {
+      _multiSelectedDateRange = range;
+    });
+  }
+
+  /// Clears all selected dates and resets the selection state
+  void _clearSelection() {
+    setState(() {
+      _multiSelectionStartDate = null;
+      _multiSelectedDateRange = <DateTime>{};
+    });
   }
 }

--- a/lib/src/components/month_view_components.dart
+++ b/lib/src/components/month_view_components.dart
@@ -9,6 +9,18 @@ import '../constants.dart';
 import '../extensions.dart';
 
 class CircularCell extends StatelessWidget {
+  /// Defines how a cell will be displayed.
+  /// For a proper view, use [CircularCell] with a [MonthViewStyle.cellAspectRatio].
+  const CircularCell({
+    required this.date,
+    Key? key,
+    this.events = const [],
+    this.shouldHighlight = false,
+    this.backgroundColor = Colors.blue,
+    this.highlightedTitleColor = Constants.white,
+    this.titleColor = Constants.black,
+  }) : super(key: key);
+
   /// Date of cell.
   final DateTime date;
 
@@ -27,25 +39,13 @@ class CircularCell extends StatelessWidget {
   /// Color of cell title.
   final Color titleColor;
 
-  /// This class will defines how cell will be displayed.
-  /// To get proper view user [CircularCell] with 1 [MonthView.cellAspectRatio].
-  const CircularCell({
-    Key? key,
-    required this.date,
-    this.events = const [],
-    this.shouldHighlight = false,
-    this.backgroundColor = Colors.blue,
-    this.highlightedTitleColor = Constants.white,
-    this.titleColor = Constants.black,
-  }) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return Center(
       child: CircleAvatar(
         backgroundColor: shouldHighlight ? backgroundColor : Colors.transparent,
         child: Text(
-          "${date.day}",
+          '${date.day}',
           style: TextStyle(
             fontSize: 20,
             color: shouldHighlight ? highlightedTitleColor : titleColor,
@@ -57,6 +57,31 @@ class CircularCell extends StatelessWidget {
 }
 
 class FilledCell<T extends Object?> extends StatelessWidget {
+  /// This class will defines how cell will be displayed.
+  /// This widget will display all the events as tile below date title.
+  const FilledCell({
+    required this.date,
+    required this.events,
+    Key? key,
+    this.isInMonth = false,
+    this.hideDaysNotInMonth = true,
+    this.shouldHighlight = false,
+    this.backgroundColor = Colors.blue,
+    this.highlightColor = Colors.blue,
+    this.onTileTap,
+    this.onTileLongTap,
+    this.onTileTapDetails,
+    this.onTileDoubleTapDetails,
+    this.onTileLongTapDetails,
+    this.tileColor = Colors.blue,
+    this.highlightRadius = 11,
+    this.titleColor = Constants.black,
+    this.highlightedTitleColor = Constants.white,
+    this.dateStringBuilder,
+    this.onTileDoubleTap,
+    this.multipleDateSelectionColor,
+  }) : super(key: key);
+
   /// Date of current cell.
   final DateTime date;
 
@@ -113,122 +138,124 @@ class FilledCell<T extends Object?> extends StatelessWidget {
   /// defines that show and hide cell not is in current month
   final bool hideDaysNotInMonth;
 
-  /// This class will defines how cell will be displayed.
-  /// This widget will display all the events as tile below date title.
-  const FilledCell({
-    Key? key,
-    required this.date,
-    required this.events,
-    this.isInMonth = false,
-    this.hideDaysNotInMonth = true,
-    this.shouldHighlight = false,
-    this.backgroundColor = Colors.blue,
-    this.highlightColor = Colors.blue,
-    this.onTileTap,
-    this.onTileLongTap,
-    this.onTileTapDetails,
-    this.onTileDoubleTapDetails,
-    this.onTileLongTapDetails,
-    this.tileColor = Colors.blue,
-    this.highlightRadius = 11,
-    this.titleColor = Constants.black,
-    this.highlightedTitleColor = Constants.white,
-    this.dateStringBuilder,
-    this.onTileDoubleTap,
-  }) : super(key: key);
+  /// Optional color overlay for multiple date selection.
+  final Color? multipleDateSelectionColor;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: backgroundColor,
-      child: Column(
+    return SizedBox.expand(
+      child: Stack(
+        fit: StackFit.expand,
         children: [
-          SizedBox(
-            height: 5.0,
-          ),
-          if (!(!isInMonth && hideDaysNotInMonth))
-            CircleAvatar(
-              radius: highlightRadius,
-              backgroundColor:
-                  shouldHighlight ? highlightColor : Colors.transparent,
-              child: Text(
-                dateStringBuilder?.call(date) ??
-                    PackageStrings.localizeNumber(date.day),
-                style: TextStyle(
-                  color: shouldHighlight ? highlightedTitleColor : titleColor,
-                  fontSize: 12,
-                ),
-              ),
-            ),
-          if (events.isNotEmpty)
-            Expanded(
-              child: Container(
-                margin: EdgeInsets.only(top: 5.0),
-                clipBehavior: Clip.antiAlias,
-                decoration: BoxDecoration(),
-                child: SingleChildScrollView(
-                  physics: BouncingScrollPhysics(),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: List.generate(
-                      events.length,
-                      (index) => GestureDetector(
-                        onTap: onTileTap.safeVoidCall(events[index], date),
-                        onLongPress:
-                            onTileLongTap.safeVoidCall(events[index], date),
-                        onDoubleTap:
-                            onTileDoubleTap.safeVoidCall(events[index], date),
-                        onTapUp: onTileTapDetails == null
-                            ? null
-                            : (details) => onTileTapDetails?.call(
-                                  events[index],
-                                  date,
-                                  details,
-                                ),
-                        onLongPressStart: onTileLongTapDetails == null
-                            ? null
-                            : (details) => onTileLongTapDetails?.call(
-                                  events[index],
-                                  date,
-                                  details,
-                                ),
-                        onDoubleTapDown: onTileDoubleTapDetails == null
-                            ? null
-                            : (details) => onTileDoubleTapDetails?.call(
-                                  events[index],
-                                  date,
-                                  details,
-                                ),
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: events[index].color,
-                            borderRadius: BorderRadius.circular(4.0),
-                          ),
-                          margin: EdgeInsets.symmetric(
-                              vertical: 2.0, horizontal: 3.0),
-                          padding: const EdgeInsets.all(2.0),
-                          alignment: Alignment.center,
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  events[index].title,
-                                  overflow: TextOverflow.clip,
-                                  maxLines: 1,
-                                  style: events[index].titleStyle ??
-                                      TextStyle(
-                                        color: events[index].color.accent,
-                                        fontSize: 12,
+          ColoredBox(
+            color: backgroundColor,
+            child: Column(
+              children: [
+                const SizedBox(height: 5),
+                if (!(!isInMonth && hideDaysNotInMonth))
+                  CircleAvatar(
+                    radius: highlightRadius,
+                    backgroundColor:
+                        shouldHighlight ? highlightColor : Colors.transparent,
+                    child: Text(
+                      dateStringBuilder?.call(date) ??
+                          PackageStrings.localizeNumber(date.day),
+                      style: TextStyle(
+                        color: shouldHighlight
+                            ? highlightedTitleColor
+                            : titleColor,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                if (events.isNotEmpty)
+                  Expanded(
+                    child: Container(
+                      margin: const EdgeInsets.only(top: 5),
+                      clipBehavior: Clip.antiAlias,
+                      decoration: const BoxDecoration(),
+                      child: SingleChildScrollView(
+                        physics: const BouncingScrollPhysics(),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: List.generate(
+                            events.length,
+                            (index) => GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onTap: onTileTap.safeVoidCall(
+                                events[index],
+                                date,
+                              ),
+                              onLongPress: onTileLongTap.safeVoidCall(
+                                events[index],
+                                date,
+                              ),
+                              onDoubleTap: onTileDoubleTap.safeVoidCall(
+                                events[index],
+                                date,
+                              ),
+                              onTapUp: onTileTapDetails == null
+                                  ? null
+                                  : (details) => onTileTapDetails?.call(
+                                        events[index],
+                                        date,
+                                        details,
                                       ),
+                              onLongPressStart: onTileLongTapDetails == null
+                                  ? null
+                                  : (details) => onTileLongTapDetails?.call(
+                                        events[index],
+                                        date,
+                                        details,
+                                      ),
+                              onDoubleTapDown: onTileDoubleTapDetails == null
+                                  ? null
+                                  : (details) => onTileDoubleTapDetails?.call(
+                                        events[index],
+                                        date,
+                                        details,
+                                      ),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: events[index].color,
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                margin: const EdgeInsets.symmetric(
+                                  vertical: 2,
+                                  horizontal: 3,
+                                ),
+                                padding: const EdgeInsets.all(2),
+                                alignment: Alignment.center,
+                                child: Row(
+                                  children: [
+                                    Expanded(
+                                      child: Text(
+                                        events[index].title,
+                                        overflow: TextOverflow.clip,
+                                        maxLines: 1,
+                                        style: events[index].titleStyle ??
+                                            TextStyle(
+                                              color: events[index].color.accent,
+                                              fontSize: 12,
+                                            ),
+                                      ),
+                                    ),
+                                  ],
                                 ),
                               ),
-                            ],
+                            ),
                           ),
                         ),
                       ),
                     ),
                   ),
-                ),
+              ],
+            ),
+          ),
+          if (multipleDateSelectionColor != null)
+            Positioned.fill(
+              child: IgnorePointer(
+                child: ColoredBox(color: multipleDateSelectionColor!),
               ),
             ),
         ],
@@ -238,6 +265,17 @@ class FilledCell<T extends Object?> extends StatelessWidget {
 }
 
 class WeekDayTile extends StatefulWidget {
+  /// Title for week day in month view.
+  const WeekDayTile({
+    required this.dayIndex,
+    Key? key,
+    this.backgroundColor,
+    this.borderColor,
+    this.displayBorder = true,
+    this.textStyle,
+    this.weekDayStringBuilder,
+  }) : super(key: key);
+
   /// Index of week day.
   final int dayIndex;
 
@@ -255,17 +293,6 @@ class WeekDayTile extends StatefulWidget {
   /// Style for week day string.
   final TextStyle? textStyle;
 
-  /// Title for week day in month view.
-  const WeekDayTile({
-    Key? key,
-    required this.dayIndex,
-    this.backgroundColor,
-    this.borderColor,
-    this.displayBorder = true,
-    this.textStyle,
-    this.weekDayStringBuilder,
-  }) : super(key: key);
-
   @override
   State<WeekDayTile> createState() => _WeekDayTileState();
 }
@@ -278,7 +305,7 @@ class _WeekDayTileState extends State<WeekDayTile> {
     return Container(
       alignment: Alignment.center,
       margin: EdgeInsets.zero,
-      padding: EdgeInsets.symmetric(vertical: 10.0),
+      padding: const EdgeInsets.symmetric(vertical: 10),
       decoration: BoxDecoration(
         color: widget.backgroundColor ?? themeColors.weekDayTileColor,
         border: widget.displayBorder

--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -8,6 +8,19 @@ import '../../calendar_view.dart';
 import '../extensions.dart';
 
 class MonthView<T extends Object?> extends StatefulWidget {
+  /// Main [Widget] to display month view.
+  const MonthView({
+    Key? key,
+    this.monthViewStyle = const MonthViewStyle(),
+    this.monthViewBuilders = const MonthViewBuilders(),
+    this.monthViewThemeSettings = const MonthViewThemeSettings(),
+    this.controller,
+    this.width,
+    this.selectedDate,
+    this.multiDateSelectionRange = const {},
+    this.multiDateSelectionColor,
+  }) : super(key: key);
+
   /// A required parameters that controls events for month view.
   ///
   /// This will auto update month view when user adds events in controller.
@@ -39,16 +52,11 @@ class MonthView<T extends Object?> extends StatefulWidget {
   /// caller and taps only trigger [MonthViewBuilders.onCellTap].
   final DateTime? selectedDate;
 
-  /// Main [Widget] to display month view.
-  const MonthView({
-    Key? key,
-    this.monthViewStyle = const MonthViewStyle(),
-    this.monthViewBuilders = const MonthViewBuilders(),
-    this.monthViewThemeSettings = const MonthViewThemeSettings(),
-    this.controller,
-    this.width,
-    this.selectedDate,
-  }) : super(key: key);
+  /// Set of dates that are selected via [MonthViewBuilders.onDateLongPressMoveUpdate]
+  final Set<DateTime> multiDateSelectionRange;
+
+  /// Color of the date cells selected via [MonthViewBuilders.onDateLongPressMoveUpdate]
+  final Color? multiDateSelectionColor;
 
   @override
   MonthViewState<T> createState() => MonthViewState<T>();
@@ -64,6 +72,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
   late int _currentIndex;
 
   int _totalMonths = 0;
+  bool _isMultiDateSelectionInProgress = false;
 
   late PageController _pageController;
 
@@ -229,6 +238,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     final textDirection = PackageStrings.currentLocale.isRTL
         ? TextDirection.rtl
         : TextDirection.ltr;
+    final columnCount = _monthViewStyle.showWeekends ? 7 : 5;
 
     return SafeAreaWrapper(
       option: _monthViewStyle.safeAreaOption,
@@ -237,14 +247,16 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Container(
+            SizedBox(
               width: _width,
               child: _headerBuilder(_currentDate),
             ),
             Expanded(
               child: PageView.builder(
                 controller: _pageController,
-                physics: _monthViewStyle.pageViewPhysics,
+                physics: _isMultiDateSelectionInProgress
+                    ? const NeverScrollableScrollPhysics()
+                    : _monthViewStyle.pageViewPhysics,
                 onPageChanged: _onPageChange,
                 itemBuilder: (_, index) {
                   final date = DateTime(_minDate.year, _minDate.month + index);
@@ -252,11 +264,11 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
                     start: _monthViewStyle.startDay,
                     showWeekEnds: _monthViewStyle.showWeekends,
                   );
-                  Widget monthPageContent = Column(
+                  final Widget monthPageContent = Column(
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Container(
+                      SizedBox(
                         width: _width,
                         child: Row(
                           children: List.generate(
@@ -280,11 +292,13 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
                                   _monthViewStyle.hideDaysNotInMonth,
                               showWeekends: _monthViewStyle.showWeekends,
                             );
+
                             final _cellAspectRatio =
                                 _monthViewStyle.useAvailableVerticalSpace
                                     ? calculateCellAspectRatio(
                                         height: constraints.maxHeight,
                                         daysInMonth: dates.length,
+                                        columnCount: columnCount,
                                       )
                                     : _monthViewStyle.cellAspectRatio;
 
@@ -296,6 +310,10 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
                                 onCellTap: _handleCellTap,
                                 onDateLongPress:
                                     _monthViewBuilders.onDateLongPress,
+                                onDateLongPressMoveUpdate: _monthViewBuilders
+                                    .onDateLongPressMoveUpdate,
+                                onLongPressSelectionStateChange:
+                                    _handleLongPressSelectionStateChange,
                                 width: _width,
                                 height: _height,
                                 controller: controller,
@@ -321,8 +339,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
 
                   if (widget.monthViewBuilders.onHasReachedEnd != null ||
                       widget.monthViewBuilders.onHasReachedStart != null) {
-                    final bool isFirstPage = index == 0;
-                    final bool isLastPage = index == _totalMonths - 1;
+                    final isFirstPage = index == 0;
+                    final isLastPage = index == _totalMonths - 1;
                     if (isFirstPage || isLastPage) {
                       return GestureDetector(
                         onHorizontalDragEnd: (details) => onHorizontalDragEnd(
@@ -373,9 +391,17 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     }
   }
 
+  void _handleLongPressSelectionStateChange(bool isInProgress) {
+    if (_isMultiDateSelectionInProgress == isInProgress || !mounted) return;
+    setState(() {
+      _isMultiDateSelectionInProgress = isInProgress;
+    });
+  }
+
   void updateViewDimensions() {
     _width = widget.width ?? MediaQuery.of(context).size.width;
-    _cellWidth = _width / 7;
+    final columnCount = _monthViewStyle.showWeekends ? 7 : 5;
+    _cellWidth = _width / columnCount;
     _cellHeight = _cellWidth / _monthViewStyle.cellAspectRatio;
     _height = _cellHeight * 6;
   }
@@ -383,10 +409,12 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
   double calculateCellAspectRatio({
     required double height,
     required int daysInMonth,
+    required int columnCount,
   }) {
-    final rows = daysInMonth / 7;
-    final _cellHeight = height / rows;
-    return _cellWidth / _cellHeight;
+    // Calculate no of rows (based on whether weekends are visible or not)
+    final rows = (daysInMonth / columnCount).ceilToDouble();
+    final cellHeight = height / rows;
+    return _cellWidth / cellHeight;
   }
 
   void _assignBuilders() {
@@ -437,8 +465,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
 
     assert(
       _minDate.isBefore(_maxDate),
-      "Minimum date should be less than maximum date.\n"
-      "Provided minimum date: $_minDate, maximum date: $_maxDate",
+      'Minimum date should be less than maximum date.\n'
+      'Provided minimum date: $_minDate, maximum date: $_maxDate',
     );
 
     // Get number of months between _minDate and _maxDate.
@@ -467,7 +495,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
       showNextIcon: date != _maxDate,
       onTitleTapped: () async {
         if (_monthViewBuilders.onHeaderTitleTap != null) {
-          _monthViewBuilders.onHeaderTitleTap!(date);
+          await _monthViewBuilders.onHeaderTitleTap!(date);
         } else {
           final selectedDate = await showDatePicker(
             context: context,
@@ -517,7 +545,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     );
   }
 
-  /// Default cell builder. Used when [widget.cellBuilder] is null
+  /// Default cell builder. Used when [_cellBuilder] is null
   Widget _defaultCellBuilder(
     DateTime date,
     List<CalendarEventData<T>> events,
@@ -526,6 +554,13 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     bool isSelected,
     bool hideDaysNotInMonth,
   ) {
+    // Normalize both the input date and selected dates to date-only (midnight)
+    // This ensures selection works regardless of time component in selectedDates
+    final normalizedDate = date.withoutTime;
+    final isMultiSelected = widget.multiDateSelectionRange.any(
+      (selectedDate) => selectedDate.withoutTime == normalizedDate,
+    );
+    final color = isMultiSelected ? widget.multiDateSelectionColor : null;
     final themeColor = context.monthViewColors;
     final shouldHighlight = isSelected || isToday;
     final highlightedTitleColor = isSelected
@@ -566,6 +601,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
         tileColor: themeColor.weekDayTileColor,
         highlightRadius: highlightRadius,
         highlightedTitleColor: highlightedTitleColor,
+        multipleDateSelectionColor: color,
       );
     }
     return FilledCell<T>(
@@ -590,6 +626,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
       highlightRadius: highlightRadius,
       tileColor: _monthViewThemeSettings.cellsInMonthTileColor,
       highlightColor: highlightColor,
+      multipleDateSelectionColor: color,
     );
   }
 
@@ -610,8 +647,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
   /// Animate to next page
   ///
   /// Arguments [duration] and [curve] will override default values provided
-  /// as [MonthView.pageTransitionDuration] and [MonthView.pageTransitionCurve]
-  /// respectively.
+  /// as [MonthViewStyle.pageTransitionDuration] and
+  /// [MonthViewStyle.pageTransitionCurve] respectively.
   void nextPage({Duration? duration, Curve? curve}) {
     _pageController.nextPage(
       duration: duration ?? _monthViewStyle.pageTransitionDuration,
@@ -622,8 +659,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
   /// Animate to previous page
   ///
   /// Arguments [duration] and [curve] will override default values provided
-  /// as [MonthView.pageTransitionDuration] and [MonthView.pageTransitionCurve]
-  /// respectively.
+  /// as [MonthViewStyle.pageTransitionDuration] and
+  /// [MonthViewStyle.pageTransitionCurve] respectively.
   void previousPage({Duration? duration, Curve? curve}) {
     _pageController.previousPage(
       duration: duration ?? _monthViewStyle.pageTransitionDuration,
@@ -639,13 +676,18 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
   /// Animate to page number [page].
   ///
   /// Arguments [duration] and [curve] will override default values provided
-  /// as [MonthView.pageTransitionDuration] and [MonthView.pageTransitionCurve]
-  /// respectively.
-  Future<void> animateToPage(int page,
-      {Duration? duration, Curve? curve}) async {
-    await _pageController.animateToPage(page,
-        duration: duration ?? _monthViewStyle.pageTransitionDuration,
-        curve: curve ?? _monthViewStyle.pageTransitionCurve);
+  /// as [MonthViewStyle.pageTransitionDuration] and
+  /// [MonthViewStyle.pageTransitionCurve] respectively.
+  Future<void> animateToPage(
+    int page, {
+    Duration? duration,
+    Curve? curve,
+  }) async {
+    await _pageController.animateToPage(
+      page,
+      duration: duration ?? _monthViewStyle.pageTransitionDuration,
+      curve: curve ?? _monthViewStyle.pageTransitionCurve,
+    );
   }
 
   /// Returns current page number.
@@ -662,10 +704,13 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
   /// Animate to page which gives month calendar for [month].
   ///
   /// Arguments [duration] and [curve] will override default values provided
-  /// as [MonthView.pageTransitionDuration] and [MonthView.pageTransitionCurve]
-  /// respectively.
-  Future<void> animateToMonth(DateTime month,
-      {Duration? duration, Curve? curve}) async {
+  /// as [MonthViewStyle.pageTransitionDuration] and
+  /// [MonthViewStyle.pageTransitionCurve] respectively.
+  Future<void> animateToMonth(
+    DateTime month, {
+    Duration? duration,
+    Curve? curve,
+  }) async {
     if (month.isBefore(_minDate) || month.isAfter(_maxDate)) {
       throw "Invalid date selected.";
     }
@@ -681,26 +726,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
 }
 
 /// A single month page.
-class _MonthPageBuilder<T> extends StatelessWidget {
-  final double cellRatio;
-  final bool showBorder;
-  final double borderSize;
-  final Color? borderColor;
-  final CellBuilder<T> cellBuilder;
-  final DateTime? selectedDate;
-  final DateTime date;
-  final EventController<T> controller;
-  final double width;
-  final double height;
-  final CellTapCallback<T>? onCellTap;
-  final DatePressCallback? onDateLongPress;
-  final WeekDays startDay;
-  final ScrollPhysics physics;
-  final bool hideDaysNotInMonth;
-  final int weekDays;
-
+class _MonthPageBuilder<T> extends StatefulWidget {
   const _MonthPageBuilder({
-    Key? key,
     required this.cellRatio,
     required this.showBorder,
     required this.borderSize,
@@ -712,72 +739,241 @@ class _MonthPageBuilder<T> extends StatelessWidget {
     required this.height,
     required this.onCellTap,
     required this.onDateLongPress,
+    required this.onDateLongPressMoveUpdate,
+    required this.onLongPressSelectionStateChange,
     required this.startDay,
     required this.physics,
     required this.hideDaysNotInMonth,
     required this.weekDays,
+    Key? key,
     this.borderColor,
   }) : super(key: key);
 
+  final double cellRatio;
+  final bool showBorder;
+  final double borderSize;
+  final Color? borderColor;
+  final CellBuilder<T> cellBuilder;
+  final DateTime date;
+  final EventController<T> controller;
+  final double width;
+  final double height;
+  final CellTapCallback<T>? onCellTap;
+  final DatePressCallback? onDateLongPress;
+  final DateLongPressMoveUpdateCallback? onDateLongPressMoveUpdate;
+  final ValueChanged<bool>? onLongPressSelectionStateChange;
+  final WeekDays startDay;
+  final ScrollPhysics physics;
+  final bool hideDaysNotInMonth;
+  final int weekDays;
+  final DateTime? selectedDate;
+
+  @override
+  State<_MonthPageBuilder<T>> createState() => _MonthPageBuilderState<T>();
+}
+
+class _MonthPageBuilderState<T> extends State<_MonthPageBuilder<T>> {
+  DateTime? _lastReportedDate;
+  bool _isLongPressActive = false;
+
+  @override
+  void dispose() {
+    _cancelLongPressTracking();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    final monthDays = date.datesOfMonths(
-      startDay: startDay,
-      hideDaysNotInMonth: hideDaysNotInMonth,
-      showWeekends: weekDays == 7,
+    final monthDays = widget.date.datesOfMonths(
+      startDay: widget.startDay,
+      hideDaysNotInMonth: widget.hideDaysNotInMonth,
+      showWeekends: widget.weekDays == 7,
     );
+    final rowCount = (monthDays.length / widget.weekDays).ceil();
 
     // Highlight tiles which is not in current month
-    return SizedBox(
-      width: width,
-      height: height,
+    final grid = SizedBox(
+      width: widget.width,
+      height: widget.height,
       child: GridView.builder(
         padding: EdgeInsets.zero,
-        physics: physics,
+        physics: widget.physics,
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: weekDays,
-          childAspectRatio: cellRatio,
+          crossAxisCount: widget.weekDays,
+          childAspectRatio: widget.cellRatio,
         ),
         itemCount: monthDays.length,
         shrinkWrap: true,
         itemBuilder: (context, index) {
           // Hide events if `hideDaysNotInMonth` true
-          final events =
-              hideDaysNotInMonth && (monthDays[index].month != date.month)
-                  ? <CalendarEventData<T>>[]
-                  : controller.getEventsOnDay(monthDays[index]);
+          final events = widget.hideDaysNotInMonth &&
+                  (monthDays[index].month != widget.date.month)
+              ? <CalendarEventData<T>>[]
+              : widget.controller.getEventsOnDay(monthDays[index]);
           final isSelected =
-              selectedDate?.compareWithoutTime(monthDays[index]) ?? false;
+              widget.selectedDate?.compareWithoutTime(monthDays[index]) ??
+                  false;
           return GestureDetector(
-            onTap: () => onCellTap?.call(events, monthDays[index]),
-            onLongPress: () => onDateLongPress?.call(monthDays[index]),
+            behavior: HitTestBehavior.opaque,
+            onTap: () => widget.onCellTap?.call(events, monthDays[index]),
             child: Container(
               decoration: BoxDecoration(
-                border: showBorder
+                border: widget.showBorder
                     ? Border.all(
-                        color: borderColor ??
+                        color: widget.borderColor ??
                             context.monthViewColors.cellBorderColor,
-                        width: borderSize,
+                        width: widget.borderSize,
                       )
                     : null,
               ),
-              child: cellBuilder(
+              child: widget.cellBuilder(
                 monthDays[index],
                 events,
                 monthDays[index].compareWithoutTime(DateTime.now()),
-                monthDays[index].month == date.month,
+                monthDays[index].month == widget.date.month,
                 isSelected,
-                hideDaysNotInMonth,
+                widget.hideDaysNotInMonth,
               ),
             ),
           );
         },
       ),
     );
+
+    if (!_hasLongPressCallbacks) {
+      return grid;
+    }
+
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onLongPressStart: (details) => _handleLongPressStart(
+        details,
+        monthDays,
+        rowCount,
+      ),
+      onLongPressMoveUpdate: (details) => _handleLongPressMoveUpdate(
+        details,
+        monthDays,
+        rowCount,
+      ),
+      onLongPressEnd: (_) => _cancelLongPressTracking(),
+      onLongPressCancel: _cancelLongPressTracking,
+      child: grid,
+    );
+  }
+
+  bool get _hasLongPressCallbacks {
+    return widget.onDateLongPress != null ||
+        widget.onDateLongPressMoveUpdate != null;
+  }
+
+  void _handleLongPressStart(
+    LongPressStartDetails details,
+    List<DateTime> monthDays,
+    int rowCount,
+  ) {
+    if (!_hasLongPressCallbacks) return;
+
+    _isLongPressActive = true;
+    widget.onLongPressSelectionStateChange?.call(true);
+    _lastReportedDate = null;
+    _notifyLongPressDate(
+      localPosition: details.localPosition,
+      globalPosition: details.globalPosition,
+      monthDays: monthDays,
+      rowCount: rowCount,
+      isMoveUpdate: false,
+    );
+  }
+
+  void _handleLongPressMoveUpdate(
+    LongPressMoveUpdateDetails details,
+    List<DateTime> monthDays,
+    int rowCount,
+  ) {
+    if (!_isLongPressActive) return;
+
+    _notifyLongPressDate(
+      localPosition: details.localPosition,
+      globalPosition: details.globalPosition,
+      monthDays: monthDays,
+      rowCount: rowCount,
+      isMoveUpdate: true,
+      moveDetails: details,
+    );
+  }
+
+  void _notifyLongPressDate({
+    required Offset localPosition,
+    required Offset globalPosition,
+    required List<DateTime> monthDays,
+    required int rowCount,
+    required bool isMoveUpdate,
+    LongPressMoveUpdateDetails? moveDetails,
+  }) {
+    final date = _getDateFromPosition(
+      localPosition: localPosition,
+      monthDays: monthDays,
+      rowCount: rowCount,
+    );
+
+    if (date == null) return;
+
+    if (date == _lastReportedDate) return;
+
+    if (!isMoveUpdate) {
+      widget.onDateLongPress?.call(date);
+    } else if (widget.onDateLongPressMoveUpdate != null) {
+      widget.onDateLongPressMoveUpdate!(
+        date,
+        moveDetails ??
+            LongPressMoveUpdateDetails(
+              globalPosition: globalPosition,
+              localPosition: localPosition,
+              offsetFromOrigin: Offset.zero,
+              localOffsetFromOrigin: Offset.zero,
+            ),
+      );
+    }
+
+    _lastReportedDate = date;
+  }
+
+  DateTime? _getDateFromPosition({
+    required Offset localPosition,
+    required List<DateTime> monthDays,
+    required int rowCount,
+  }) {
+    final size = context.size;
+    if (size == null || size.width <= 0 || size.height <= 0) return null;
+    if (localPosition.dx < 0 ||
+        localPosition.dy < 0 ||
+        localPosition.dx >= size.width ||
+        localPosition.dy >= size.height) {
+      return null;
+    }
+
+    final columnWidth = size.width / widget.weekDays;
+    final rowHeight = size.height / rowCount;
+    final column = (localPosition.dx / columnWidth).floor();
+    final row = (localPosition.dy / rowHeight).floor();
+    final index = row * widget.weekDays + column;
+
+    if (index < 0 || index >= monthDays.length) return null;
+    return monthDays[index];
+  }
+
+  void _cancelLongPressTracking() {
+    final wasLongPressActive = _isLongPressActive;
+    _lastReportedDate = null;
+    _isLongPressActive = false;
+    if (wasLongPressActive) {
+      widget.onLongPressSelectionStateChange?.call(false);
+    }
   }
 }
 
 class MonthHeader {
   /// Hide Header Widget
-  static Widget hidden(DateTime date) => SizedBox.shrink();
+  static Widget hidden(DateTime date) => const SizedBox.shrink();
 }

--- a/lib/src/month_view/month_view_builders.dart
+++ b/lib/src/month_view/month_view_builders.dart
@@ -15,7 +15,8 @@ import '../../calendar_view.dart';
 /// * React to page changes using [onPageChange].
 /// * Handle taps and gestures on dates and events using callbacks such as
 ///   [onCellTap], [onDateLongPress], [onEventTap], [onEventLongTap],
-///   [onEventDoubleTap] and their corresponding `*Details` variants.
+///   [onEventDoubleTap], [onDateLongPressMoveUpdate] and their
+///   corresponding `*Details` variants.
 ///
 /// Note that [onHeaderTitleTap] and [headerBuilder] are mutually
 /// exclusive; providing both at the same time is not allowed and will
@@ -35,6 +36,7 @@ class MonthViewBuilders<T extends Object?> {
     this.onEventDoubleTap,
     this.weekDayBuilder,
     this.onDateLongPress,
+    this.onDateLongPressMoveUpdate,
     this.onHeaderTitleTap,
     this.onEventTapDetails,
     this.onEventLongTapDetails,
@@ -101,6 +103,10 @@ class MonthViewBuilders<T extends Object?> {
 
   /// This method will be called when user long press on calendar.
   final DatePressCallback? onDateLongPress;
+
+  /// This method will be called when user moves after a long press
+  /// on a month cell.
+  final DateLongPressMoveUpdateCallback? onDateLongPressMoveUpdate;
 
   /// Callback for the Header title
   final HeaderTitleCallback? onHeaderTitleTap;

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -100,6 +100,11 @@ typedef CellTapCallback<T extends Object?> = void Function(
 
 typedef DatePressCallback = void Function(DateTime date);
 
+typedef DateLongPressMoveUpdateCallback = void Function(
+  DateTime date,
+  LongPressMoveUpdateDetails details,
+);
+
 typedef DateTapCallback = void Function(DateTime date);
 
 typedef TimestampCallback = void Function(DateTime date);


### PR DESCRIPTION
# Description

This PR enhances the MonthView widget to support multi-date selection using long-press and drag gestures. Users can now select a range of dates by long-pressing on a date and dragging to another date, with the selected range visually highlighted. Tapping on a selected date displays the count of selected dates. The update also improves user feedback with contextual snack bars and ensures the selection logic is robust and user-friendly.

- Added support for selecting a range of dates in MonthView via long-press and drag.
- Improved feedback for selection actions with snack bars.
- Refactored selection logic for better maintainability and UX.
- Ensured compatibility with existing event tap and navigation behaviors.

This change addresses a highly requested feature for multi-date selection in the calendar view.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`feat:`).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #401

## Feature Demo

https://github.com/user-attachments/assets/0c1275f5-5d3a-4908-945e-cdeec0f097ff

