### PR TITLE
🔨 Fixes issue #527: Add optional pageDate parameter for timeline label customization with current timestamp fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed `MonthViewBuilder` to be generic for improved type safety in `MonthView`. [#524](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/524)
 - Added `DividerSerttings` to customize the dividers in `WeekView` and `MultiDayView`. [#374](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/374), [#430](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/430), [#498](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/498)
 - Added `timeSlotColorBuilder` in `DayView` and `WeekView` to customize background color. [#470](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/470)
+- Added `pageDate` parameter for timeline label customization with current timestamp fallback. [#527](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/527)
 
 # [2.0.0 - 17 Mar 2026](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/2.0.0)
 

--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -200,6 +200,12 @@ class TimeLine extends StatefulWidget {
   /// This field will be used to set end hour for day and week view
   final int endHour;
 
+  /// Visible date used to build timeline labels and tap callbacks.
+  ///
+  /// When omitted, the current date from [LiveTimeIndicatorSettings]
+  /// is used for backward-compatible internal behavior.
+  final DateTime? pageDate;
+
   /// Time line to display time at left side of day or week view.
   const TimeLine({
     Key? key,
@@ -214,6 +220,7 @@ class TimeLine extends StatefulWidget {
     this.showQuarterHours = false,
     required this.liveTimeIndicatorSettings,
     this.endHour = Constants.hoursADay,
+    this.pageDate,
   }) : super(key: key);
 
   @override
@@ -338,12 +345,12 @@ class _TimeLineState extends State<TimeLine> {
     required int hour,
     int minutes = 0,
   }) {
-    final currentDateTime = _getCurrentDateTime();
+    final labelDate = widget.pageDate ?? _getCurrentDateTime();
 
     final dateTime = DateTime(
-      currentDateTime.year,
-      currentDateTime.month,
-      currentDateTime.day,
+      labelDate.year,
+      labelDate.month,
+      labelDate.day,
       hour,
       minutes,
     );

--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -403,6 +403,7 @@ class _InternalDayViewPageState<T extends Object?>
                       timeLineBuilder: widget.timeLineBuilder,
                       timeLineOffset: widget.timeLineOffset,
                       timeLineWidth: widget.timeLineWidth,
+                      pageDate: widget.date,
                       showHalfHours: widget.showHalfHours,
                       startHour: widget.startHour,
                       endHour: widget.endHour,

--- a/lib/src/multi_day_view/_internal_multi_day_view_page.dart
+++ b/lib/src/multi_day_view/_internal_multi_day_view_page.dart
@@ -529,6 +529,8 @@ class _InternalMultiDayViewPageState<T extends Object?>
                       height: widget.height,
                       timeLineOffset: widget.timeLineOffset,
                       timeLineBuilder: widget.timeLineBuilder,
+                      pageDate:
+                          widget.dates.isEmpty ? null : widget.dates.first,
                       startHour: widget.startHour,
                       showHalfHours: widget.showHalfHours,
                       showQuarterHours: widget.showQuarterHours,

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -599,6 +599,8 @@ class _InternalWeekViewPageState<T extends Object?>
                       height: widget.height,
                       timeLineOffset: widget.timeLineOffset,
                       timeLineBuilder: widget.timeLineBuilder,
+                      pageDate:
+                          filteredDates.isEmpty ? null : filteredDates.first,
                       startHour: widget.startHour,
                       showHalfHours: widget.showHalfHours,
                       showQuarterHours: widget.showQuarterHours,


### PR DESCRIPTION
# Description

This PR fixes timeline date semantics in DayView, WeekView, and MultiDayView by introducing an optional pageDate input in the shared TimeLine widget.

Previous behavior:
- Timeline label/tap DateTime values were always derived from current time via LiveTimeIndicatorSettings currentTimeProvider or DateTime.now.
- When users navigated to a non-current date, timeline labels and timestamp callbacks could carry the wrong year-month-day.

What this PR changes:
- Adds an optional pageDate field to TimeLine.
- Uses pageDate to build timeline label DateTime values when provided.
- Falls back to existing current-time behavior when pageDate is not provided (backward-compatible fallback).
- Passes the visible date into TimeLine from:
  - InternalDayViewPage using widget.date
  - InternalWeekViewPage using first visible filtered date
  - InternalMultiDayViewPage using first visible date in widget.dates

Motivation:
- Ensure timeline labels and timestamp tap callbacks align with the currently visible page date.
- Preserve existing behavior for live-time overlap logic and compatibility.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (fix:, feat:, docs: etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in docs and added dartdoc comments with ///.
- [ ] I have updated/added relevant examples in examples or docs.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #527

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org