### PR TITLE
✨Fixes issue #233: Add selectedDate control to MonthView for external date management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `DividerSerttings` to customize the dividers in `WeekView` and `MultiDayView`. [#374](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/374), [#430](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/430), [#498](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/498)
 - Added `timeSlotColorBuilder` in `DayView` and `WeekView` to customize background color. [#470](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/470)
 - Added `pageDate` parameter for timeline label customization with current timestamp fallback. [#527](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/527)
+- [BREAKING] Added `selectedDate` control to `MonthView` for external date management. [#233](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/233)
 
 # [2.0.0 - 17 Mar 2026](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/2.0.0)
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -142,35 +142,41 @@ This guide covers more advanced features and customization options for the calen
 ```dart
 MonthView(
     controller: EventController(),
-    // Custom UI for month cells
-    cellBuilder: (date, events, isToday, isInMonth, hideDaysNotInMonth) {
+    selectedDate: DateTime(2021, 8, 10),
+    monthViewBuilders: MonthViewBuilders(
+      // Custom UI for month cells
+      cellBuilder: (date, events, isToday, isInMonth, isSelected, hideDaysNotInMonth) {
         // Return your widget to display as month cell.
         return Container();
-    },
-    minMonth: DateTime(1990),
-    maxMonth: DateTime(2050),
-    initialMonth: DateTime(2021),
-    cellAspectRatio: 1,
-    onPageChange: (date, pageIndex) => print("$date, $pageIndex"),
-    onCellTap: (events, date) {
+      },
+      onPageChange: (date, pageIndex) => print("$date, $pageIndex"),
+      onCellTap: (events, date) {
         // Implement callback when user taps on a cell.
+        // Update selectedDate here if you want controlled selection.
         print(events);
-    },
-    startDay: WeekDays.sunday, // To change the first day of the week.
-    // Event callbacks
-    onEventTap: (event, data) => print('on tap'),
-    onEventTapDetails: (event, data, details) => print('on tap details'),
-    onEventDoubleTap: (event, data) => print('on double tap'),
-    onEventDoubleTapDetails: (event, data, details) =>
-      print('on double details'),
-    onEventLongTap: (event, data) => print('on long tap'),
-    onEventLongTapDetails: (event, data, details) =>
-      print('on long tap details'),
-    onDateLongPress: (date) => print(date),
-    headerBuilder: MonthHeader.hidden, // To hide month header
-    showWeekTileBorder: false, // To show or hide header border
-    hideDaysNotInMonth: true, // To hide days or cell that are not in current month
-    showWeekends: false, // To hide weekends default value is true
+      },
+      // Event callbacks
+      onEventTap: (event, data) => print('on tap'),
+      onEventTapDetails: (event, data, details) => print('on tap details'),
+      onEventDoubleTap: (event, data) => print('on double tap'),
+      onEventDoubleTapDetails: (event, data, details) =>
+        print('on double details'),
+      onEventLongTap: (event, data) => print('on long tap'),
+      onEventLongTapDetails: (event, data, details) =>
+        print('on long tap details'),
+      onDateLongPress: (date) => print(date),
+      headerBuilder: MonthHeader.hidden, // To hide month header
+    ),
+    monthViewStyle: MonthViewStyle(
+      minMonth: DateTime(1990),
+      maxMonth: DateTime(2050),
+      initialMonth: DateTime(2021),
+      cellAspectRatio: 1,
+      startDay: WeekDays.sunday, // To change the first day of the week.
+      showWeekTileBorder: false, // To show or hide header border
+      hideDaysNotInMonth: true, // To hide days or cell that are not in current month
+      showWeekends: false, // To hide weekends default value is true
+    ),
 );
 ```
 
@@ -687,29 +693,33 @@ Hide divider in week view.
 ### Month view
 
 * Default date cell color in month is `colorScheme.surfaceContainerLowest` and `colorScheme.surfaceContainerLow` for days not in month.
-* Use `cellBuilder` to completely customize the cell appearance:
+* Use `monthViewBuilders.cellBuilder` to completely customize the cell appearance:
 
   ```dart
-  cellBuilder: (date, events, isToday, isInMonth, hideDaysNotInMonth) {
-    return Container(
-      decoration: BoxDecoration(
-        color: isInMonth ? Colors.white : Colors.grey[200],
-        border: Border.all(color: Colors.blue),
-      ),
-      child: Center(
-        child: Text(
-          date.day.toString(),
-          style: TextStyle(
-            color: isToday ? Colors.red : Colors.black,
-            fontWeight: isToday ? FontWeight.bold : FontWeight.normal,
+  MonthView(
+    monthViewBuilders: MonthViewBuilders(
+      cellBuilder: (date, events, isToday, isInMonth, isSelected, hideDaysNotInMonth) {
+        return Container(
+          decoration: BoxDecoration(
+            color: isInMonth ? Colors.white : Colors.grey[200],
+            border: Border.all(color: Colors.blue),
           ),
-        ),
-      ),
-    );
-  }
+          child: Center(
+            child: Text(
+              date.day.toString(),
+              style: TextStyle(
+                color: isSelected ? Colors.white : (isToday ? Colors.red : Colors.black),
+                fontWeight: (isToday || isSelected) ? FontWeight.bold : FontWeight.normal,
+              ),
+            ),
+          ),
+        );
+      },
+    ),
+  )
   ```
-* Use `showWeekTileBorder` to control week day title border visibility
-* Use `headerBuilder` to customize or completely replace the month header
+* Use `monthViewStyle.showWeekTileBorder` to control week day title border visibility
+* Use `monthViewBuilders.headerBuilder` to customize or completely replace the month header
 
 # Migration Guides
 

--- a/example/lib/widgets/month_view_widget.dart
+++ b/example/lib/widgets/month_view_widget.dart
@@ -4,20 +4,37 @@ import 'package:flutter/material.dart';
 
 import '../pages/event_details_page.dart';
 
-class MonthViewWidget extends StatelessWidget {
+class MonthViewWidget extends StatefulWidget {
   final GlobalKey<MonthViewState>? state;
   final double? width;
 
   const MonthViewWidget({super.key, this.state, this.width});
 
   @override
+  State<MonthViewWidget> createState() => _MonthViewWidgetState();
+}
+
+class _MonthViewWidgetState extends State<MonthViewWidget> {
+  late DateTime _selectedDate;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDate = DateTime.now().withoutTime;
+  }
+
+  @override
   Widget build(BuildContext context) {
     final translate = context.translate;
     return MonthView(
-      key: state,
-      width: width,
+      key: widget.state,
+      width: widget.width,
+      selectedDate: _selectedDate,
       monthViewThemeSettings: MonthViewThemeSettings(
         cellsInMonthHighlightColor: Colors.blue,
+        selectedHighlightColor: Colors.deepOrange,
+        selectedTitleColor: Colors.white,
+        selectedHighlightRadius: 12,
       ),
       monthViewStyle: MonthViewStyle(
         startDay: WeekDays.friday,
@@ -43,6 +60,8 @@ class MonthViewWidget extends StatelessWidget {
           );
           ScaffoldMessenger.of(context).showSnackBar(snackBar);
         },
+        onCellTap: (events, date) =>
+            setState(() => _selectedDate = date.withoutTime),
         onEventTap: (event, date) {
           Navigator.of(context).push(
             MaterialPageRoute(

--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -32,6 +32,13 @@ class MonthView<T extends Object?> extends StatefulWidget {
   /// If null is provided then It will take width of closest [MediaQuery].
   final double? width;
 
+  /// Controls the selected date in the month grid.
+  ///
+  /// When null, the view manages selection internally and updates it when a
+  /// visible cell is tapped. When non-null, selection is controlled by the
+  /// caller and taps only trigger [MonthViewBuilders.onCellTap].
+  final DateTime? selectedDate;
+
   /// Main [Widget] to display month view.
   const MonthView({
     Key? key,
@@ -40,6 +47,7 @@ class MonthView<T extends Object?> extends StatefulWidget {
     this.monthViewThemeSettings = const MonthViewThemeSettings(),
     this.controller,
     this.width,
+    this.selectedDate,
   }) : super(key: key);
 
   @override
@@ -64,6 +72,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
 
   late double _cellWidth;
   late double _cellHeight;
+
+  DateTime? _selectedDate;
 
   late CellBuilder<T> _cellBuilder;
 
@@ -92,6 +102,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     _currentDate = (_monthViewStyle.initialMonth ?? DateTime.now()).withoutTime;
 
     _regulateCurrentDate();
+
+    _selectedDate = widget.selectedDate?.withoutTime;
 
     // Initialize page controller to control page actions.
 
@@ -150,6 +162,12 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
 
     // Update builders and callbacks
     _assignBuilders();
+
+    if (widget.selectedDate != null) {
+      _selectedDate = widget.selectedDate?.withoutTime;
+    } else if (oldWidget.selectedDate != null) {
+      _selectedDate = oldWidget.selectedDate?.withoutTime;
+    }
 
     updateViewDimensions();
   }
@@ -275,7 +293,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
                               width: _width,
                               child: _MonthPageBuilder<T>(
                                 key: ValueKey(date.toIso8601String()),
-                                onCellTap: _monthViewBuilders.onCellTap,
+                                onCellTap: _handleCellTap,
                                 onDateLongPress:
                                     _monthViewBuilders.onDateLongPress,
                                 width: _width,
@@ -284,6 +302,7 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
                                 borderColor: _monthViewStyle.borderColor,
                                 borderSize: _monthViewStyle.borderSize,
                                 cellBuilder: _cellBuilder,
+                                selectedDate: _selectedDate,
                                 cellRatio: _cellAspectRatio,
                                 date: date,
                                 showBorder: _monthViewStyle.showBorder,
@@ -338,6 +357,14 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     }
 
     return _controller!;
+  }
+
+  bool _isSameDate(DateTime? first, DateTime? second) {
+    if (first == null || second == null) {
+      return first == second;
+    }
+
+    return first.withoutTime.compareWithoutTime(second.withoutTime);
   }
 
   void _reload() {
@@ -496,14 +523,31 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     List<CalendarEventData<T>> events,
     bool isToday,
     bool isInMonth,
+    bool isSelected,
     bool hideDaysNotInMonth,
   ) {
     final themeColor = context.monthViewColors;
+    final shouldHighlight = isSelected || isToday;
+    final highlightedTitleColor = isSelected
+        ? _monthViewThemeSettings.selectedTitleColor
+        : hideDaysNotInMonth
+            ? _monthViewThemeSettings.cellsNotInMonthHighlightedTitleColor
+            : _monthViewThemeSettings.cellsInMonthHighlightedTitleColor;
+    final highlightColor = isSelected
+        ? _monthViewThemeSettings.selectedHighlightColor
+        : hideDaysNotInMonth
+            ? themeColor.cellHighlightColor
+            : _monthViewThemeSettings.cellsInMonthHighlightColor;
+    final highlightRadius = isSelected
+        ? _monthViewThemeSettings.selectedHighlightRadius
+        : hideDaysNotInMonth
+            ? _monthViewThemeSettings.cellsNotInMonthHighlightRadius
+            : _monthViewThemeSettings.cellsInMonthHighlightRadius;
 
     if (hideDaysNotInMonth) {
       return FilledCell<T>(
         date: date,
-        shouldHighlight: isToday,
+        shouldHighlight: shouldHighlight,
         backgroundColor: isInMonth
             ? themeColor.cellInMonthColor
             : themeColor.cellNotInMonthColor,
@@ -518,16 +562,15 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
         dateStringBuilder: _monthViewBuilders.dateStringBuilder,
         hideDaysNotInMonth: hideDaysNotInMonth,
         titleColor: themeColor.cellTextColor,
-        highlightColor: themeColor.cellHighlightColor,
+        highlightColor: highlightColor,
         tileColor: themeColor.weekDayTileColor,
-        highlightRadius: _monthViewThemeSettings.cellsNotInMonthHighlightRadius,
-        highlightedTitleColor:
-            _monthViewThemeSettings.cellsNotInMonthHighlightedTitleColor,
+        highlightRadius: highlightRadius,
+        highlightedTitleColor: highlightedTitleColor,
       );
     }
     return FilledCell<T>(
       date: date,
-      shouldHighlight: isToday,
+      shouldHighlight: shouldHighlight,
       backgroundColor: isInMonth
           ? themeColor.cellInMonthColor
           : themeColor.cellNotInMonthColor,
@@ -543,12 +586,25 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
       titleColor: isInMonth
           ? themeColor.cellTextColor
           : themeColor.cellTextColor.withAlpha(150),
-      highlightedTitleColor:
-          _monthViewThemeSettings.cellsInMonthHighlightedTitleColor,
-      highlightRadius: _monthViewThemeSettings.cellsInMonthHighlightRadius,
+      highlightedTitleColor: highlightedTitleColor,
+      highlightRadius: highlightRadius,
       tileColor: _monthViewThemeSettings.cellsInMonthTileColor,
-      highlightColor: _monthViewThemeSettings.cellsInMonthHighlightColor,
+      highlightColor: highlightColor,
     );
+  }
+
+  /// Handles cell tap event. Updates selected date if [widget.selectedDate]
+  /// is null and calls [MonthViewBuilders.onCellTap] callback.
+  void _handleCellTap(List<CalendarEventData<T>> events, DateTime date) {
+    if (widget.selectedDate == null &&
+        !_isSameDate(_selectedDate, date.withoutTime) &&
+        mounted) {
+      setState(() {
+        _selectedDate = date.withoutTime;
+      });
+    }
+
+    _monthViewBuilders.onCellTap?.call(events, date);
   }
 
   /// Animate to next page
@@ -631,6 +687,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
   final double borderSize;
   final Color? borderColor;
   final CellBuilder<T> cellBuilder;
+  final DateTime? selectedDate;
   final DateTime date;
   final EventController<T> controller;
   final double width;
@@ -648,6 +705,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
     required this.showBorder,
     required this.borderSize,
     required this.cellBuilder,
+    required this.selectedDate,
     required this.date,
     required this.controller,
     required this.width,
@@ -688,6 +746,8 @@ class _MonthPageBuilder<T> extends StatelessWidget {
               hideDaysNotInMonth && (monthDays[index].month != date.month)
                   ? <CalendarEventData<T>>[]
                   : controller.getEventsOnDay(monthDays[index]);
+          final isSelected =
+              selectedDate?.compareWithoutTime(monthDays[index]) ?? false;
           return GestureDetector(
             onTap: () => onCellTap?.call(events, monthDays[index]),
             onLongPress: () => onDateLongPress?.call(monthDays[index]),
@@ -706,6 +766,7 @@ class _MonthPageBuilder<T> extends StatelessWidget {
                 events,
                 monthDays[index].compareWithoutTime(DateTime.now()),
                 monthDays[index].month == date.month,
+                isSelected,
                 hideDaysNotInMonth,
               ),
             ),

--- a/lib/src/month_view/month_view_theme_settings.dart
+++ b/lib/src/month_view/month_view_theme_settings.dart
@@ -3,9 +3,8 @@ import 'package:flutter/material.dart';
 import '../../calendar_view.dart';
 import '../constants.dart';
 
-@immutable
-
 /// Month view theme settings.
+@immutable
 class MonthViewThemeSettings {
   /// Creates a default month view theme settings.
   const MonthViewThemeSettings({
@@ -20,6 +19,9 @@ class MonthViewThemeSettings {
     this.cellsInMonthHighlightRadius = 11,
     this.cellsInMonthTileColor = Colors.blue,
     this.cellsInMonthHighlightColor = Colors.blue,
+    this.selectedHighlightColor = Colors.blue,
+    this.selectedTitleColor = Constants.white,
+    this.selectedHighlightRadius = 11,
   });
 
   /// Default border color for week day cells.
@@ -55,6 +57,15 @@ class MonthViewThemeSettings {
   /// Highlight color for cells in the current month.
   final Color cellsInMonthHighlightColor;
 
+  /// Highlight color for the selected date.
+  final Color selectedHighlightColor;
+
+  /// Title color for the selected date.
+  final Color selectedTitleColor;
+
+  /// Highlight radius for the selected date.
+  final double selectedHighlightRadius;
+
   /// Creates a copy of this theme settings with the given fields replaced.
   MonthViewThemeSettings copyWith({
     Color? weekDayBorderColor,
@@ -68,6 +79,9 @@ class MonthViewThemeSettings {
     double? cellsInMonthHighlightRadius,
     Color? cellsInMonthTileColor,
     Color? cellsInMonthHighlightColor,
+    Color? selectedHighlightColor,
+    Color? selectedTitleColor,
+    double? selectedHighlightRadius,
   }) {
     return MonthViewThemeSettings(
       weekDayBorderColor: weekDayBorderColor ?? this.weekDayBorderColor,
@@ -89,6 +103,11 @@ class MonthViewThemeSettings {
           cellsInMonthTileColor ?? this.cellsInMonthTileColor,
       cellsInMonthHighlightColor:
           cellsInMonthHighlightColor ?? this.cellsInMonthHighlightColor,
+      selectedHighlightColor:
+          selectedHighlightColor ?? this.selectedHighlightColor,
+      selectedTitleColor: selectedTitleColor ?? this.selectedTitleColor,
+      selectedHighlightRadius:
+          selectedHighlightRadius ?? this.selectedHighlightRadius,
     );
   }
 
@@ -109,6 +128,9 @@ class MonthViewThemeSettings {
       cellsInMonthHighlightRadius: other.cellsInMonthHighlightRadius,
       cellsInMonthTileColor: other.cellsInMonthTileColor,
       cellsInMonthHighlightColor: other.cellsInMonthHighlightColor,
+      selectedHighlightColor: other.selectedHighlightColor,
+      selectedTitleColor: other.selectedTitleColor,
+      selectedHighlightRadius: other.selectedHighlightRadius,
     );
   }
 }

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -11,6 +11,7 @@ typedef CellBuilder<T extends Object?> = Widget Function(
   List<CalendarEventData<T>> event,
   bool isToday,
   bool isInMonth,
+  bool isSelected,
   bool hideDaysNotInMonth,
 );
 

--- a/test/month_view_selected_date_test.dart
+++ b/test/month_view_selected_date_test.dart
@@ -1,0 +1,93 @@
+import 'package:calendar_view/calendar_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MonthView selectedDate', () {
+    testWidgets('tracks tapped date internally when selectedDate is null',
+        (tester) async {
+      DateTime? tappedDate;
+
+      await tester.pumpWidget(
+        _buildMonthView(
+          onCellTap: (_, date) => tappedDate = date,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('2026-5-15-idle'), findsOneWidget);
+      expect(find.text('2026-5-20-selected'), findsNothing);
+
+      await tester.tap(find.text('2026-5-15-idle'));
+      await tester.pump();
+
+      expect(find.text('2026-5-15-selected'), findsOneWidget);
+      expect(tappedDate, DateTime(2026, 5, 15));
+    });
+
+    testWidgets('uses external selectedDate when provided', (tester) async {
+      DateTime? tappedDate;
+
+      await tester.pumpWidget(
+        _buildMonthView(
+          selectedDate: DateTime(2026, 5, 13),
+          onCellTap: (_, date) => tappedDate = date,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('2026-5-13-selected'), findsOneWidget);
+      expect(find.text('2026-5-15-idle'), findsOneWidget);
+
+      await tester.tap(find.text('2026-5-15-idle'));
+      await tester.pump();
+
+      expect(find.text('2026-5-13-selected'), findsOneWidget);
+      expect(find.text('2026-5-15-selected'), findsNothing);
+      expect(tappedDate, DateTime(2026, 5, 15));
+    });
+  });
+}
+
+Widget _buildMonthView({
+  DateTime? selectedDate,
+  CellTapCallback<Object?>? onCellTap,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 420,
+        height: 420,
+        child: MonthView<Object?>(
+          width: 420,
+          controller: EventController<Object?>(),
+          selectedDate: selectedDate,
+          monthViewStyle: MonthViewStyle(
+            initialMonth: DateTime(2026, 5, 1),
+            minMonth: DateTime(2026, 5, 1),
+            maxMonth: DateTime(2026, 5, 31),
+            hideDaysNotInMonth: false,
+            pagePhysics: NeverScrollableScrollPhysics(),
+          ),
+          monthViewBuilders: MonthViewBuilders<Object?>(
+            onCellTap: onCellTap,
+            cellBuilder: (
+              date,
+              events,
+              isToday,
+              isInMonth,
+              isSelected,
+              hideDaysNotInMonth,
+            ) {
+              return Center(
+                child: Text(
+                  '${date.year}-${date.month}-${date.day}-${isSelected ? 'selected' : 'idle'}',
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Description

This PR adds selected-date support to MonthView so consumers can either control date selection externally or let MonthView manage it internally.

### Existing behavior

- MonthView did not expose a selectedDate API.
- Selection state was effectively internal and not externally controllable.
- Custom month cell builders did not receive selected-state information.

### New behavior in this PR

- Added selectedDate to MonthView for controlled selection.
- Preserved uncontrolled behavior when selectedDate is null (MonthView updates selected date on tap).
- onCellTap still fires in both controlled and uncontrolled modes.
- Extended CellBuilder to include isSelected so custom UI can react to selection state.
- Added selected-state theme options in MonthViewThemeSettings:
  - selectedHighlightColor
  - selectedTitleColor
  - selectedHighlightRadius
- Updated docs and example app to demonstrate controlled selected-date usage and selected styling.
- Added widget tests for controlled and uncontrolled selected-date behavior.

### Breaking change details

Yes. This PR includes a breaking API change in CellBuilder.

Before:

    cellBuilder: (date, events, isToday, isInMonth, hideDaysNotInMonth) {
      return Container();
    }

After:

    cellBuilder: (date, events, isToday, isInMonth, isSelected, hideDaysNotInMonth) {
      return Container();
    }

This change is required so custom month cells can render selected state consistently with the new selectedDate feature.

## Checklist

- [x] The title of my PR starts with a Conventional Commit prefix (fix:, feat:, docs: etc).
- [x] I have followed the Contributor Guide when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in docs and added dartdoc comments with ///.
- [x] I have updated/added relevant examples in examples or docs.

## Breaking Change?

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

## Related Issues

Closes #233