### PR TITLE
fix: 🔨 extend scaffold background behind status bar in multi day view example

### DIFF
--- a/example/lib/pages/multi_day_view_page.dart
+++ b/example/lib/pages/multi_day_view_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../enumerations.dart';
 import '../extension.dart';
-import '../widgets/responsive_widget.dart';
 import '../widgets/multi_day_view_widget.dart';
+import '../widgets/responsive_widget.dart';
 import 'create_event_page.dart';
 import 'web/web_home_page.dart';
 
@@ -20,6 +20,8 @@ class _MultiDayViewDemoState extends State<MultiDayViewDemo> {
     return ResponsiveWidget(
       webWidget: WebHomePage(selectedView: CalendarView.week),
       mobileWidget: Scaffold(
+        primary: false,
+        appBar: AppBar(leading: const SizedBox.shrink()),
         floatingActionButton: FloatingActionButton(
           child: Icon(Icons.add, color: context.appColors.onPrimary),
           elevation: 8,


### PR DESCRIPTION
# Description

This PR updates the **multi day view example** so the scaffold background extends behind the status bar on mobile.  
Previously, the top system area did not visually blend with the screen background, which caused the status bar region to appear disconnected from the rest of the page. With this change, the example now renders a matching background behind the status bar by adding a minimal `AppBar` and setting `primary: false` on the `Scaffold`.

This change only affects the example app (`example/lib/pages/multi_day_view_page.dart`) and also adds an entry to `CHANGELOG.md`.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

This PR does **not** introduce any breaking API or behavioral changes for package consumers. It only adjusts the visual presentation of the multi day view example app.

## Related Issues

N/A

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org

## Screenshots
| Before | After |
|---|---|
| <img width="300" alt="Before" src="https://github.com/user-attachments/assets/69de4039-2505-4354-bd98-44e43ba67185" /> | <img width="300" alt="After" src="https://github.com/user-attachments/assets/c313d502-9737-488f-ac03-179534ec641c" /> |

