### PR TITLE
✨ Fixes issue #492: add option to display midnight hour in timeline views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `timeSlotColorBuilder` in `DayView` and `WeekView` to customize background color. [#470](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/470)
 - Added `pageDate` parameter for timeline label customization with current timestamp fallback. [#527](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/527)
 - [BREAKING] Added `selectedDate` control to `MonthView` for external date management. [#233](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/233)
+- Added `showMidnightHour` parameter in `DayView` and `WeekView` to control whether the `00:00` label is shown on the timeline. Default is `false`. [#492](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/492)
 
 # [2.0.0 - 17 Mar 2026](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/2.0.0)
 

--- a/example/lib/widgets/day_view_widget.dart
+++ b/example/lib/widgets/day_view_widget.dart
@@ -23,6 +23,7 @@ class DayViewWidget extends StatelessWidget {
       scrollPhysics: const BouncingScrollPhysics(),
       eventArranger: SideEventArranger(),
       showQuarterHours: false,
+      showMidnightHour: true,
       hourIndicatorSettings: HourIndicatorSettings(
         color: Theme.of(context).dividerColor,
       ),

--- a/example/lib/widgets/week_view_widget.dart
+++ b/example/lib/widgets/week_view_widget.dart
@@ -15,6 +15,7 @@ class WeekViewWidget extends StatelessWidget {
       key: state,
       width: width,
       showWeekends: true,
+      showMidnightHour: true,
       showLiveTimeLineInAllDays: true,
       timeSlotColorBuilder: (_, slotStartTime, __, ___) {
         final hour = slotStartTime.hour;

--- a/lib/src/components/_internal_components.dart
+++ b/lib/src/components/_internal_components.dart
@@ -206,6 +206,12 @@ class TimeLine extends StatefulWidget {
   /// is used for backward-compatible internal behavior.
   final DateTime? pageDate;
 
+  /// Flag to display the 00:00 (midnight) hour in the timeline.
+  ///
+  /// When set to true, the 00:00 label will be shown on the timeline.
+  /// Default value is false.
+  final bool showMidnightHour;
+
   /// Time line to display time at left side of day or week view.
   const TimeLine({
     Key? key,
@@ -215,12 +221,13 @@ class TimeLine extends StatefulWidget {
     required this.timeLineOffset,
     required this.timeLineBuilder,
     required this.onTimestampTap,
+    required this.liveTimeIndicatorSettings,
+    this.pageDate,
     this.startHour = 0,
     this.showHalfHours = false,
     this.showQuarterHours = false,
-    required this.liveTimeIndicatorSettings,
     this.endHour = Constants.hoursADay,
-    this.pageDate,
+    this.showMidnightHour = false,
   }) : super(key: key);
 
   @override
@@ -284,53 +291,56 @@ class _TimeLineState extends State<TimeLine> {
       ),
       child: Stack(
         children: [
-          for (int i = widget.startHour + 1; i < widget.endHour; i++)
-            _timelinePositioned(
-              topPosition: widget.hourHeight * (i - widget.startHour) -
-                  widget.timeLineOffset,
-              bottomPosition: widget.height -
-                  (widget.hourHeight * (i - widget.startHour + 1)) +
-                  widget.timeLineOffset,
-              hour: i,
-            ),
+          for (int i = widget.startHour; i < widget.endHour; i++)
+            if (widget.showMidnightHour || i != 0)
+              _timelinePositioned(
+                topPosition: widget.hourHeight * (i - widget.startHour) -
+                    widget.timeLineOffset,
+                bottomPosition: widget.height -
+                    (widget.hourHeight * (i - widget.startHour + 1)) +
+                    widget.timeLineOffset,
+                hour: i,
+              ),
           if (widget.showHalfHours)
             for (int i = widget.startHour; i < widget.endHour; i++)
-              _timelinePositioned(
-                topPosition: widget.hourHeight * (i - widget.startHour) -
-                    widget.timeLineOffset +
-                    widget._halfHourHeight,
-                bottomPosition: widget.height -
-                    (widget.hourHeight * (i - widget.startHour + 1)) +
-                    widget.timeLineOffset,
-                hour: i,
-                minutes: 30,
-              ),
+              if (widget.showMidnightHour || i != 0)
+                _timelinePositioned(
+                  topPosition: widget.hourHeight * (i - widget.startHour) -
+                      widget.timeLineOffset +
+                      widget._halfHourHeight,
+                  bottomPosition: widget.height -
+                      (widget.hourHeight * (i - widget.startHour + 1)) +
+                      widget.timeLineOffset,
+                  hour: i,
+                  minutes: 30,
+                ),
           if (widget.showQuarterHours)
-            for (int i = widget.startHour; i < widget.endHour; i++) ...[
-              /// this is for 15 minutes
-              _timelinePositioned(
-                topPosition: widget.hourHeight * (i - widget.startHour) -
-                    widget.timeLineOffset +
-                    widget.hourHeight * 0.25,
-                bottomPosition: widget.height -
-                    (widget.hourHeight * (i - widget.startHour + 1)) +
-                    widget.timeLineOffset,
-                hour: i,
-                minutes: 15,
-              ),
+            for (int i = widget.startHour; i < widget.endHour; i++)
+              if (widget.showMidnightHour || i != 0) ...[
+                /// this is for 15 minutes
+                _timelinePositioned(
+                  topPosition: widget.hourHeight * (i - widget.startHour) -
+                      widget.timeLineOffset +
+                      widget.hourHeight * 0.25,
+                  bottomPosition: widget.height -
+                      (widget.hourHeight * (i - widget.startHour + 1)) +
+                      widget.timeLineOffset,
+                  hour: i,
+                  minutes: 15,
+                ),
 
-              /// this is for 45 minutes
-              _timelinePositioned(
-                topPosition: widget.hourHeight * (i - widget.startHour) -
-                    widget.timeLineOffset +
-                    widget.hourHeight * 0.75,
-                bottomPosition: widget.height -
-                    (widget.hourHeight * (i - widget.startHour + 1)) +
-                    widget.timeLineOffset,
-                hour: i,
-                minutes: 45,
-              ),
-            ],
+                /// this is for 45 minutes
+                _timelinePositioned(
+                  topPosition: widget.hourHeight * (i - widget.startHour) -
+                      widget.timeLineOffset +
+                      widget.hourHeight * 0.75,
+                  bottomPosition: widget.height -
+                      (widget.hourHeight * (i - widget.startHour + 1)) +
+                      widget.timeLineOffset,
+                  hour: i,
+                  minutes: 45,
+                ),
+              ],
         ],
       ),
     );

--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -142,6 +142,12 @@ class InternalDayViewPage<T extends Object?> extends StatefulWidget {
   /// A callback for rendering custom time slot background colors.
   final TimeSlotColorBuilder? timeSlotColorBuilder;
 
+  /// Flag to display the 00:00 (midnight) hour in the timeline.
+  ///
+  /// When set to true, the 00:00 label will be shown on the timeline.
+  /// Default value is false.
+  final bool showMidnightHour;
+
   /// Defines a single day page.
   const InternalDayViewPage({
     Key? key,
@@ -172,7 +178,6 @@ class InternalDayViewPage<T extends Object?> extends StatefulWidget {
     required this.dayViewScrollController,
     required this.scrollPhysics,
     required this.scrollListener,
-    this.lastScrollOffset = 0.0,
     required this.dayDetectorBuilder,
     required this.showHalfHours,
     required this.showQuarterHours,
@@ -183,8 +188,10 @@ class InternalDayViewPage<T extends Object?> extends StatefulWidget {
     required this.emulateVerticalOffsetBy,
     required this.onTileDoubleTap,
     required this.onTimestampTap,
-    this.keepScrollOffset = false,
     this.timeSlotColorBuilder,
+    this.lastScrollOffset = 0.0,
+    this.keepScrollOffset = false,
+    this.showMidnightHour = false,
   }) : super(key: key);
 
   @override
@@ -412,6 +419,7 @@ class _InternalDayViewPageState<T extends Object?>
                       liveTimeIndicatorSettings:
                           widget.liveTimeIndicatorSettings,
                       onTimestampTap: widget.onTimestampTap,
+                      showMidnightHour: widget.showMidnightHour,
                     ),
                     if (widget.showLiveLine &&
                         widget.liveTimeIndicatorSettings.height > 0)

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -231,6 +231,9 @@ class DayView<T extends Object?> extends StatefulWidget {
   /// Useful for highlighting unavailable hours, business hours, or blocked time.
   final TimeSlotColorBuilder? timeSlotColorBuilder;
 
+  /// Flag to display the 00:00 (midnight) hour in the timeline.
+  final bool showMidnightHour;
+
   /// Main widget for day view.
   const DayView({
     Key? key,
@@ -283,6 +286,7 @@ class DayView<T extends Object?> extends StatefulWidget {
     this.keepScrollOffset = false,
     this.onTimestampTap,
     this.timeSlotColorBuilder,
+    this.showMidnightHour = false,
   })  : assert(!(onHeaderTitleTap != null && dayTitleBuilder != null),
             "can't use [onHeaderTitleTap] & [dayTitleBuilder] simultaneously"),
         assert(timeLineOffset >= 0,
@@ -518,6 +522,7 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
                             scrollListener: _scrollPageListener,
                             keepScrollOffset: widget.keepScrollOffset,
                             timeSlotColorBuilder: _timeSlotColorBuilder,
+                            showMidnightHour: widget.showMidnightHour,
                           ),
                         );
                       },

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -173,6 +173,12 @@ class InternalWeekViewPage<T extends Object?> extends StatefulWidget {
   /// A callback for rendering custom time slot background colors.
   final TimeSlotColorBuilder? timeSlotColorBuilder;
 
+  /// Flag to display the 00:00 (midnight) hour in the timeline.
+  ///
+  /// When set to true, the 00:00 label will be shown on the timeline.
+  /// Default value is false.
+  final bool showMidnightHour;
+
   /// A single page for week view.
   const InternalWeekViewPage({
     Key? key,
@@ -218,15 +224,16 @@ class InternalWeekViewPage<T extends Object?> extends StatefulWidget {
     required this.onTileDoubleTap,
     required this.endHour,
     required this.onTimestampTap,
-    this.fullDayHeaderTitle = '',
     required this.fullDayHeaderTextConfig,
     required this.scrollPhysics,
     required this.scrollListener,
     required this.weekViewScrollController,
-    this.lastScrollOffset = 0.0,
-    this.keepScrollOffset = false,
     this.backgroundColor,
     this.timeSlotColorBuilder,
+    this.fullDayHeaderTitle = '',
+    this.lastScrollOffset = 0.0,
+    this.keepScrollOffset = false,
+    this.showMidnightHour = false,
   }) : super(key: key);
 
   @override
@@ -608,6 +615,7 @@ class _InternalWeekViewPageState<T extends Object?>
                           widget.liveTimeIndicatorSettings,
                       endHour: widget.endHour,
                       onTimestampTap: widget.onTimestampTap,
+                      showMidnightHour: widget.showMidnightHour,
                     ),
                     if (widget.showLiveLine &&
                         widget.liveTimeIndicatorSettings.height > 0)

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -251,6 +251,9 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// Useful for highlighting unavailable hours, business hours, or blocked time.
   final TimeSlotColorBuilder? timeSlotColorBuilder;
 
+  /// Flag to display the 00:00 (midnight) hour in the timeline.
+  final bool showMidnightHour;
+
   /// Main widget for week view.
   const WeekView({
     Key? key,
@@ -314,6 +317,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
     this.keepScrollOffset = false,
     this.onTimestampTap,
     this.timeSlotColorBuilder,
+    this.showMidnightHour = false,
   })  : assert(!(onHeaderTitleTap != null && weekPageHeaderBuilder != null),
             "can't use [onHeaderTitleTap] & [weekPageHeaderBuilder] simultaneously"),
         assert((timeLineOffset) >= 0,
@@ -590,6 +594,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                           scrollListener: _scrollPageListener,
                           keepScrollOffset: widget.keepScrollOffset,
                           timeSlotColorBuilder: _timeSlotColorBuilder,
+                          showMidnightHour: widget.showMidnightHour,
                         ),
                       );
                     },


### PR DESCRIPTION
# Description
This PR adds a new `showMidnightHour` parameter to the `DayView` and `WeekView` widgets, allowing users to control whether the midnight hour (00:00) label is displayed on the timeline. 

This PR is created on top of https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/pull/493

Previously, the midnight hour was not visible by default. With this change, the parameter defaults to `false` in `DayView` and `WeekView`, hiding the midnight label unless explicitly enabled, giving users the option to configure it. The underlying `TimeLine` component has been updated to respect this flag, ensuring consistent behavior across full, half, and quarter-hour increments.

No APIs were changed in a breaking way; the new parameter is optional and backward-compatible.

## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
Closes #492

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org