### PR TITLE
📝 Fixes issue #448: Enhance documentation for DayView, WeekView, MonthView and MultiDayView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [BREAKING] Added `selectedDate` control to `MonthView` for external date management. [#233](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/233)
 - Added `showMidnightHour` parameter in `DayView` and `WeekView` to control whether the `00:00` label is shown on the timeline. Default is `false`. [#492](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/492)
 - Added `onDateLongPressMoveUpdate` callback to `MonthView`, along with `MonthView.multiDateSelectionRange`, `MonthView.multiDateSelectionColor`, and `FilledCell.multipleDateSelectionColor` for multi-date selection customization.  [#401](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/401)
+- Updated documentation for `DayView`, `WeekView`, `MonthView` adn `MultidayView` to add more details about the parameters and their usage. [#448](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/pull/448)
 
 # [2.0.0 - 17 Mar 2026](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/tree/2.0.0)
 

--- a/lib/src/day_view/day_view.dart
+++ b/lib/src/day_view/day_view.dart
@@ -12,6 +12,7 @@ import '../extensions.dart';
 import '../painters.dart';
 import '_internal_day_view_page.dart';
 
+/// Displays a single-day calendar view and renders events for that day.
 class DayView<T extends Object?> extends StatefulWidget {
   /// A function that returns a [Widget] that determines appearance of each
   /// cell in day calendar.
@@ -19,10 +20,14 @@ class DayView<T extends Object?> extends StatefulWidget {
 
   /// A function to generate the DateString in the calendar title.
   /// Useful for I18n
+  ///
+  /// If not provided, a default date format will be used.
   final StringProvider? dateStringBuilder;
 
   /// A function to generate the TimeString in the timeline.
   /// Useful for I18n
+  ///
+  /// If not provided, a default time format will be used.
   final StringProvider? timeStringBuilder;
 
   /// A function that returns a [Widget] that will be displayed left side of
@@ -56,9 +61,10 @@ class DayView<T extends Object?> extends StatefulWidget {
   /// This callback will run whenever page will change.
   final CalendarPageChangeCallBack? onPageChange;
 
-  /// Determines the lower boundary user can scroll.
+  /// Determines the lower boundary user can scroll (base date for page indexing).
   ///
-  /// If not provided [CalendarConstants.epochDate] is default.
+  /// **Important:** Use same [minDay] across all views (day/week/month) when
+  /// switching between them to ensure consistent date-to-page mapping.
   final DateTime? minDay;
 
   /// Determines upper boundary user can scroll.
@@ -98,10 +104,14 @@ class DayView<T extends Object?> extends StatefulWidget {
 
   /// Page transition duration used when user try to change page using
   /// [DayViewState.nextPage] or [DayViewState.previousPage]
+  ///
+  /// Default value is 300 milliseconds.
   final Duration pageTransitionDuration;
 
   /// Page transition curve used when user try to change page using
   /// [DayViewState.nextPage] or [DayViewState.previousPage]
+  ///
+  /// Default value is [Curves.ease].
   final Curve pageTransitionCurve;
 
   /// A required parameters that controls events for day view.
@@ -113,6 +123,12 @@ class DayView<T extends Object?> extends StatefulWidget {
 
   /// Defines height occupied by one minute of interval.
   /// This will be used to calculate total height of day view.
+  ///
+  /// For example, if [heightPerMinute] is 0.7, then one hour (60 minutes)
+  /// will occupy 42 pixels of height (0.7 * 60).
+  ///
+  /// Default value is 0.7.
+  /// Must be greater than 0.
   final double heightPerMinute;
 
   /// Defines the width of timeline. If null then it will
@@ -155,11 +171,16 @@ class DayView<T extends Object?> extends StatefulWidget {
   /// Defines initial offset of first page that will be displayed when
   /// [DayView] is initialized.
   ///
-  /// If [scrollOffset] is null then [startDuration] will be considered for
-  /// initial offset.
+  /// This controls the scroll position within the day view. If [scrollOffset]
+  /// is null, then [startDuration] will be considered for initial offset.
+  ///
+  /// Use this when you want to start the view at a specific scroll position
+  /// rather than relying on the [startDuration] parameter.
   final double? scrollOffset;
 
   /// This method will be called when user taps on timestamp in timeline.
+  ///
+  /// Called when user taps on a time value in the timeline (left side of view).
   final TimestampCallback? onTimestampTap;
 
   /// This method will be called when user taps on event tile.
@@ -185,12 +206,23 @@ class DayView<T extends Object?> extends StatefulWidget {
 
   /// Defines size of the slots that provides long press callback on area
   /// where events are not there.
+  ///
+  /// This determines the granularity of time selections. For example,
+  /// [MinuteSlotSize.minutes60] means each slot represents 60 minutes (1 hour).
+  ///
+  /// Default value is [MinuteSlotSize.minutes60].
   final MinuteSlotSize minuteSlotSize;
 
   /// Use this field to disable the calendar scrolling
+  ///
+  /// If specified, this [ScrollPhysics] will be applied to the time axis scrolling.
+  /// Set to [NeverScrollableScrollPhysics] to disable scrolling within the day view.
   final ScrollPhysics? scrollPhysics;
 
   /// Use this field to disable the page view scrolling behavior
+  ///
+  /// If specified, this [ScrollPhysics] will be applied to the horizontal page transitions.
+  /// Set to [NeverScrollableScrollPhysics] to disable day-to-day page swiping.
   final ScrollPhysics? pageViewPhysics;
 
   /// Style for DayView header.
@@ -200,15 +232,30 @@ class DayView<T extends Object?> extends StatefulWidget {
   final SafeAreaOption safeAreaOption;
 
   /// Display full day event builder.
+  ///
+  /// A custom widget builder for displaying events that span the entire day.
+  /// If not provided, [FullDayEventView] will be used as default.
   final FullDayEventBuilder<T>? fullDayEventBuilder;
 
   /// First hour displayed in the layout, goes from 0 to 24
+  ///
+  /// This determines the starting hour of the visible time range.
+  /// For example, if [startHour] is 6, the timeline will start from 6:00 AM.
+  ///
+  /// Default value is 0 (starts from midnight).
+  /// Must be less than or equal to [endHour].
   final int startHour;
 
   /// Show half hour indicator
+  ///
+  /// When true, displays horizontal lines at 30-minute intervals.
+  /// Default value is false.
   final bool showHalfHours;
 
   /// Show quarter hour indicator(15min & 45min).
+  ///
+  /// When true, displays horizontal lines at 15-minute intervals (15min & 45min).
+  /// Default value is false.
   final bool showQuarterHours;
 
   /// It define the starting duration from where day view page will be visible
@@ -216,15 +263,32 @@ class DayView<T extends Object?> extends StatefulWidget {
   final Duration startDuration;
 
   /// Callback for the Header title
+  ///
+  /// Called when user taps on the header title/date. If not provided,
+  /// a date picker dialog will be shown.
   final HeaderTitleCallback? onHeaderTitleTap;
 
   /// Emulate vertical line offset from hour line starts.
+  ///
+  /// This adjusts the vertical line position by the specified amount.
+  /// Default value is 0.
   final double emulateVerticalOffsetBy;
 
   /// This field will be used to set end hour for day view
+  ///
+  /// This determines the ending hour of the visible time range.
+  /// For example, if [endHour] is 24, the timeline will end at midnight.
+  ///
+  /// Default value is 24.
+  /// Must be greater than [startHour].
   final int endHour;
 
   /// Flag to keep scrollOffset of pages on page change
+  ///
+  /// When true, maintains the scroll position when navigating between days.
+  /// When false, resets to [startDuration] on each page change.
+  ///
+  /// Default value is false.
   final bool keepScrollOffset;
 
   /// A callback that resolves slot background color for each visible time slot.
@@ -317,47 +381,124 @@ class DayView<T extends Object?> extends StatefulWidget {
 }
 
 class DayViewState<T extends Object?> extends State<DayView<T>> {
+  /// Width of the Day View widget in pixels.
+  /// Calculated from widget width or device constraint width.
   late double _width;
+
+  /// Total height of the visible day view (calculated from hourHeight and hour range).
+  /// Formula: _hourHeight * (endHour - startHour)
   late double _height;
+
+  /// Width allocated for the timeline/hour labels on the left side.
+  /// Defaults to 13% of _width if not explicitly specified.
   late double _timeLineWidth;
+
+  /// Height occupied by a single hour in pixels.
+  /// Formula: heightPerMinute * 60
+  /// This is used to determine overall view height and scroll calculations.
   late double _hourHeight;
+
+  /// Last recorded scroll offset position for maintaining scroll state.
+  /// Used when navigating between pages if keepScrollOffset is enabled.
   late double _lastScrollOffset;
+
+  /// Currently displayed day in the Day View.
+  /// Updated when user navigates between days.
+  /// Always stored without time component (time is 00:00:00).
   late DateTime _currentDate;
+
+  /// Maximum date user can scroll to.
+  /// Derived from widget.maxDay parameter (defaults to CalendarConstants.maxDate).
+  /// Stored without time component.
   late DateTime _maxDate;
+
+  /// Minimum date user can scroll to.
+  /// This is the **reference date** for calculating page indices.
+  /// Derived from widget.minDay parameter (defaults to CalendarConstants.epochDate).
+  /// Stored without time component.
   late DateTime _minDate;
+
+  /// Total number of days available in the calendar.
+  /// Calculated as: (_maxDate - _minDate) + 1
   late int _totalDays;
+
+  /// Current page index in the PageView controller.
+  /// Represents the number of days since _minDate.
+  /// Central to relating page indices with dates.
+  /// Formula: currentDate.getDayDifference(_minDate)
   late int _currentIndex;
 
+  /// Event arrangement strategy for positioning events in the day view.
+  /// Determines how overlapping events are laid out (side-by-side, cascading, etc.).
+  /// Defaults to SideEventArranger if not provided.
   late EventArranger<T> _eventArranger;
 
+  /// Settings for full hour indicator lines (e.g., solid lines at each hour mark).
+  /// Controls color, height, offset, and line style for 1-hour interval indicators.
   late HourIndicatorSettings _hourIndicatorSettings;
+
+  /// Settings for half-hour indicator lines (at 30-minute marks).
+  /// Controls color, height, offset, and line style for half-hour interval indicators.
   late HourIndicatorSettings _halfHourIndicatorSettings;
+
+  /// Settings for quarter-hour indicator lines (at 15 and 45-minute marks).
+  /// Controls color, height, offset, and line style for quarter-hour interval indicators.
   late HourIndicatorSettings _quarterHourIndicatorSettings;
+
+  /// Custom painter for drawing hour lines in the day view.
+  /// Allows fine-grained control over line rendering appearance.
   late CustomHourLinePainter _hourLinePainter;
 
+  /// Settings for the live time indicator (current time line).
+  /// Controls color, height, and offset of the indicator showing current time.
   late LiveTimeIndicatorSettings _liveTimeIndicatorSettings;
+
+  /// Builder for adding custom colors to time slots in the day view.
   late TimeSlotColorBuilder? _timeSlotColorBuilder;
 
+  /// Controller for managing page transitions between days.
+  /// Used for jumpToPage(), animateToPage(), and nextPage/previousPage operations.
   late PageController _pageController;
 
+  /// Builder function for creating timeline/hour labels on the left side.
+  /// Receives the date and returns a Widget to display for that hour.
   late DateWidgetBuilder _timeLineBuilder;
 
+  /// Builder function for creating event tiles within the day view.
+  /// Customizes how individual events are rendered.
   late EventTileBuilder<T> _eventTileBuilder;
 
+  /// Builder function for creating the day title/header section.
+  /// Typically displays the current date and navigation controls.
   late DateWidgetBuilder _dayTitleBuilder;
 
+  /// Builder function for creating full-day event displays.
+  /// Handles rendering of events that span the entire day.
   late FullDayEventBuilder<T> _fullDayEventBuilder;
 
+  /// Builder function for creating the press detector overlay.
+  /// Handles tap, long-press detection for creating new events.
   late DetectorBuilder _dayDetectorBuilder;
 
+  /// Event controller for managing calendar events.
+  /// Can be null if event management is not needed.
+  /// Provides data for rendering events and tracks event changes.
   EventController<T>? _controller;
 
+  /// Scroll controller for managing vertical scrolling within the day view.
+  /// Controls scroll position for time axis (top-to-bottom).
   late ScrollController _scrollController;
 
+  /// Public getter for accessing the scroll controller.
+  /// Allows external code to control or listen to scroll events.
   ScrollController get scrollController => _scrollController;
 
+  /// Callback function triggered when the controller changes or events are modified.
+  /// Used to rebuild the view when event data changes.
   late VoidCallback _reloadCallback;
 
+  /// Configuration for handling scroll events when jumping/animating to specific events.
+  /// Manages ValueNotifier for reactive scroll updates.
   final _scrollConfiguration = EventScrollConfiguration<T>();
 
   @override
@@ -550,7 +691,6 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   }
 
   /// Reloads page.
-  ///
   void _reload() {
     if (mounted) {
       setState(() {});
@@ -626,7 +766,6 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   ///
   /// If maximum and minimum dates are change then first call _setDateRange
   /// and then _regulateCurrentDate method.
-  ///
   void _regulateCurrentDate() {
     if (_currentDate.isBefore(_minDate)) {
       _currentDate = _minDate;
@@ -653,7 +792,6 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
 
   /// Default press detector builder. This builder will be used if
   /// [widget.weekDetectorBuilder] is null.
-  ///
   Widget _defaultPressDetectorBuilder({
     required DateTime date,
     required double height,
@@ -674,7 +812,6 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
 
   /// Default timeline builder this builder will be used if
   /// [widget.eventTileBuilder] is null
-  ///
   Widget _defaultTimeLineBuilder(DateTime date) => DefaultTimeLineMark(
         date: date,
         timeStringBuilder: widget.timeStringBuilder,
@@ -686,7 +823,6 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
 
   /// Default timeline builder. This builder will be used if
   /// [widget.eventTileBuilder] is null
-  ///
   Widget _defaultEventTileBuilder(
     DateTime date,
     List<CalendarEventData<T>> events,
@@ -810,56 +946,69 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
     widget.onPageChange?.call(_currentDate, _currentIndex);
   }
 
-  /// Animate to next page
+  /// Animate to next page (next day).
   ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
+  /// Transitions with animation using [pageTransitionDuration] and [pageTransitionCurve].
   ///
-  ///
+  /// See also: [previousPage], [jumpToDate], [animateToDate]
   void nextPage({Duration? duration, Curve? curve}) => _pageController.nextPage(
         duration: duration ?? widget.pageTransitionDuration,
         curve: curve ?? widget.pageTransitionCurve,
       );
 
-  /// Animate to previous page
+  /// Animate to previous page (previous day).
   ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
+  /// Transitions with animation using [pageTransitionDuration] and [pageTransitionCurve].
   ///
-  ///
+  /// See also: [nextPage], [jumpToDate], [animateToDate]
   void previousPage({Duration? duration, Curve? curve}) =>
       _pageController.previousPage(
         duration: duration ?? widget.pageTransitionDuration,
         curve: curve ?? widget.pageTransitionCurve,
       );
 
-  /// Jumps to page number [page]
+  /// Jumps to page index without animation.
   ///
+  /// **Page Index Formula:** `pageIndex = date.getDayDifference(minDay)`
   ///
+  /// **Prefer:** Use [jumpToDate] instead of this method for date-based navigation.
+  ///
+  /// **Throws:** Exception if page index is invalid.
+  ///
+  /// See also: [jumpToDate], [animateToPage]
   void jumpToPage(int page) => _pageController.jumpToPage(page);
 
-  /// Animate to page number [page].
+  /// Animates to page index with animation.
   ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
+  /// Arguments [duration] and [curve] override default transition values.
   ///
+  /// **Page Index Formula:** `pageIndex = date.getDayDifference(minDay)`
   ///
+  /// **Prefer:** Use [animateToDate] instead of this method for date-based navigation.
+  ///
+  /// See also: [animateToDate], [jumpToPage]
   Future<void> animateToPage(int page, {Duration? duration, Curve? curve}) =>
       _pageController.animateToPage(page,
           duration: duration ?? widget.pageTransitionDuration,
           curve: curve ?? widget.pageTransitionCurve);
 
-  /// Returns current page number.
-  ///
-  ///
+  /// Returns current page index (number of days since [minDay]).
   int get currentPage => _currentIndex;
 
   /// Jumps to page which gives day calendar for [date]
   ///
+  /// This is the preferred way to navigate to a specific date. It automatically
+  /// calculates the correct page index based on the [minDay] parameter.
   ///
+  /// **Example:**
+  /// ```dart
+  /// dayViewState.jumpToDate(DateTime(2024, 5, 15));
+  /// ```
+  ///
+  /// **Note:** The [date] must be within the range [minDay] to [maxDay],
+  /// otherwise an exception will be thrown.
+  ///
+  /// Throws an exception if [date] is outside the valid date range.
   void jumpToDate(DateTime date) {
     if (date.isBefore(_minDate) || date.isAfter(_maxDate)) {
       throw "Invalid date selected.";
@@ -869,11 +1018,10 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
 
   /// Animate to page which gives day calendar for [date].
   ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
+  /// Calculates the correct page index based on [minDay] and animates to it.
+  /// Arguments [duration] and [curve] override default transition values.
   ///
-  ///
+  /// Throws an exception if [date] is outside the [minDay] to [maxDay] range.
   Future<void> animateToDate(DateTime date,
       {Duration? duration, Curve? curve}) async {
     if (date.isBefore(_minDate) || date.isAfter(_maxDate)) {
@@ -889,6 +1037,14 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   /// Jumps to page which contains given events and make event
   /// tile visible to user.
   ///
+  /// This method performs two operations:
+  /// 1. Jumps to the page (day) containing the event
+  /// 2. Scrolls to make the event tile visible
+  ///
+  /// **Example:**
+  /// ```dart
+  /// await dayViewState.jumpToEvent(myCalendarEvent);
+  /// ```
   Future<void> jumpToEvent(CalendarEventData<T> event) async {
     jumpToDate(event.date);
 
@@ -902,17 +1058,27 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   /// Animate to page which contains given events and make event
   /// tile visible to user.
   ///
+  /// This method performs two operations with animation:
+  /// 1. Animates to the page (day) containing the event
+  /// 2. Scrolls with animation to make the event tile visible
+  ///
   /// Arguments [duration] and [curve] will override default values provided
   /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
   /// respectively.
   ///
-  /// Actual duration will be 2 times the given duration.
+  /// **Actual duration:** The total animation time will be 2 times the given duration:
+  /// - First [duration]: animate to page
+  /// - Second [duration]: scroll to event tile
   ///
-  /// Ex, If provided duration is 200 milliseconds then this function will take
-  /// 200 milliseconds for animate to page then 200 milliseconds for
-  /// scroll to event tile.
+  /// **Example:**
+  /// If provided duration is 200 milliseconds, total animation time is 400 milliseconds.
   ///
-  ///
+  /// ```dart
+  /// await dayViewState.animateToEvent(
+  ///   myCalendarEvent,
+  ///   duration: Duration(milliseconds: 300),
+  /// );
+  /// ```
   Future<void> animateToEvent(CalendarEventData<T> event,
       {Duration? duration, Curve? curve}) async {
     await animateToDate(event.date, duration: duration, curve: curve);
@@ -924,6 +1090,24 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   }
 
   /// Animate to specific offset in a day view using the start duration
+  ///
+  /// This method scrolls to a specific time of day within the currently displayed page.
+  ///
+  /// **Parameters:**
+  /// - [startDuration]: The time to scroll to (e.g., Duration(hours: 10) for 10:00 AM)
+  /// - [duration]: Animation duration (default: 200ms)
+  /// - [curve]: Animation curve (default: Curves.linear)
+  ///
+  /// **Example:**
+  /// Scroll to 2:30 PM:
+  /// ```dart
+  /// await dayViewState.animateToDuration(
+  ///   Duration(hours: 14, minutes: 30),
+  ///   duration: Duration(milliseconds: 500),
+  /// );
+  /// ```
+  ///
+  /// **Note:** If the duration exceeds 24 hours, it will be capped at 24 hours.
   Future<void> animateToDuration(
     Duration startDuration, {
     Duration duration = const Duration(milliseconds: 200),
@@ -944,6 +1128,18 @@ class DayViewState<T extends Object?> extends State<DayView<T>> {
   }
 
   /// Animate to specific scroll controller offset
+  ///
+  /// This method scrolls to a specific pixel offset within the current page.
+  ///
+  /// **Parameters:**
+  /// - [offset]: Target scroll offset in pixels
+  /// - [duration]: Animation duration (default: 200ms)
+  /// - [curve]: Animation curve (default: Curves.linear)
+  ///
+  /// **Example:**
+  /// ```dart
+  /// dayViewState.animateTo(500.0);
+  /// ```
   void animateTo(
     double offset, {
     Duration duration = const Duration(milliseconds: 200),

--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -64,38 +64,68 @@ class MonthView<T extends Object?> extends StatefulWidget {
 
 /// State of month view.
 class MonthViewState<T extends Object?> extends State<MonthView<T>> {
+  /// Minimum date user can scroll to. Reference date for page index calculation.
+  /// Stored without time component. See [_setDateRange] for calculation.
   late DateTime _minDate;
+
+  /// Maximum date user can scroll to. Aligned to month boundary.
+  /// Stored without time component. See [_setDateRange] for calculation.
   late DateTime _maxDate;
 
+  /// Currently displayed month. Updated when user navigates between months.
   late DateTime _currentDate;
 
+  /// Current page index in PageView. Calculated from date difference.
+  /// See [_regulateCurrentDate] for calculation: `pageIndex = minDate.getMonthDifference(currentDate) - 1`
   late int _currentIndex;
 
+  /// Total number of months available between _minDate and _maxDate.
+  /// See [_setDateRange] for calculation.
   int _totalMonths = 0;
+
+  /// Whether multi date selection is in progress.
   bool _isMultiDateSelectionInProgress = false;
 
+  /// Controls page transitions between months (horizontal paging).
   late PageController _pageController;
 
+  /// Total width of the month view widget in pixels.
   late double _width;
+
+  /// Total height available for displaying month cells.
   late double _height;
 
+  /// Width of each cell in the month grid. Calculated as: `_width / 7`
   late double _cellWidth;
+
+  /// Height of each cell in the month grid. Calculated based on cellAspectRatio.
   late double _cellHeight;
 
+  /// Current selected date (single date).
   DateTime? _selectedDate;
 
+  /// Builder function for rendering individual calendar cells.
   late CellBuilder<T> _cellBuilder;
 
+  /// Builder function for rendering week day headers (Mon, Tue, etc).
   late WeekDayBuilder _weekBuilder;
 
+  /// Builder function for rendering the month view header.
   late DateWidgetBuilder _headerBuilder;
 
+  /// Event controller for managing calendar events across the month.
   EventController<T>? _controller;
 
+  /// Callback triggered when events change or rebuild is needed.
   late VoidCallback _reloadCallback;
 
+  /// Current style configuration for the month view layout and appearance.
   late MonthViewStyle _monthViewStyle = widget.monthViewStyle;
+
+  /// Current custom builders for month view components.
   late MonthViewBuilders<T> _monthViewBuilders = widget.monthViewBuilders;
+
+  /// Current theme settings for month view colors and text styles.
   late MonthViewThemeSettings _monthViewThemeSettings =
       widget.monthViewThemeSettings;
 
@@ -107,7 +137,6 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     _setDateRange();
 
     // Initialize current date.
-
     _currentDate = (_monthViewStyle.initialMonth ?? DateTime.now()).withoutTime;
 
     _regulateCurrentDate();
@@ -115,7 +144,6 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     _selectedDate = widget.selectedDate?.withoutTime;
 
     // Initialize page controller to control page actions.
-
     _pageController = PageController(initialPage: _currentIndex);
 
     _assignBuilders();
@@ -644,11 +672,13 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     _monthViewBuilders.onCellTap?.call(events, date);
   }
 
-  /// Animate to next page
+  /// Animate to next page (next month).
   ///
   /// Arguments [duration] and [curve] will override default values provided
   /// as [MonthViewStyle.pageTransitionDuration] and
   /// [MonthViewStyle.pageTransitionCurve] respectively.
+  ///
+  /// See also: [previousPage], [jumpToMonth], [animateToMonth]
   void nextPage({Duration? duration, Curve? curve}) {
     _pageController.nextPage(
       duration: duration ?? _monthViewStyle.pageTransitionDuration,
@@ -656,11 +686,13 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     );
   }
 
-  /// Animate to previous page
+  /// Animate to previous page (previous month).
   ///
   /// Arguments [duration] and [curve] will override default values provided
   /// as [MonthViewStyle.pageTransitionDuration] and
   /// [MonthViewStyle.pageTransitionCurve] respectively.
+  ///
+  /// See also: [nextPage], [jumpToMonth], [animateToMonth]
   void previousPage({Duration? duration, Curve? curve}) {
     _pageController.previousPage(
       duration: duration ?? _monthViewStyle.pageTransitionDuration,
@@ -668,16 +700,32 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     );
   }
 
-  /// Jumps to page number [page]
+  /// Jumps to page index without animation.
+  ///
+  /// **Page Index Formula:** `pageIndex = month.getMonthDifference(minMonth) - 1`
+  /// For calculation details, see [jumpToMonth].
+  ///
+  /// **Prefer:** Use [jumpToMonth] instead of this method for date-based navigation.
+  ///
+  /// See also: [jumpToMonth], [animateToPage]
   void jumpToPage(int page) {
     _pageController.jumpToPage(page);
   }
 
-  /// Animate to page number [page].
+  /// Animates to the specified page index with animation.
   ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [MonthViewStyle.pageTransitionDuration] and
-  /// [MonthViewStyle.pageTransitionCurve] respectively.
+  /// The [page] parameter represents the page index calculated as:
+  /// `pageIndex = minMonth.getMonthDifference(targetMonth) - 1`
+  ///
+  /// Optional [duration] and [curve] parameters override the default transition
+  /// values from [MonthViewStyle.pageTransitionDuration] and
+  /// [MonthViewStyle.pageTransitionCurve].
+  ///
+  /// **Recommendation:** For date-based navigation, prefer using [animateToMonth]
+  /// instead, as it accepts a [DateTime] and handles the page index calculation
+  /// automatically.
+  ///
+  /// See also: [animateToMonth], [jumpToPage], [jumpToMonth]
   Future<void> animateToPage(
     int page, {
     Duration? duration,
@@ -690,7 +738,11 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     );
   }
 
-  /// Returns current page number.
+  /// Returns current page index (number of months since [minMonth]).
+  ///
+  /// Use [currentDate] to get the current month as a DateTime.
+  ///
+  /// See also: [currentDate], [jumpToMonth]
   int get currentPage => _currentIndex;
 
   /// Jumps to page which gives month calendar for [month]

--- a/lib/src/month_view/month_view_style.dart
+++ b/lib/src/month_view/month_view_style.dart
@@ -36,14 +36,15 @@ class MonthViewStyle {
   /// Default value is true.
   final bool showWeekends;
 
-  /// Determines the lower boundary user can scroll.
+  /// Determines the lower boundary user can scroll (base date for page indexing).
   ///
-  /// If not provided [CalendarConstants.epochDate] is default.
+  /// **Important:** Use same [minMonth] across all views (day/week/month) when
+  /// switching between them to ensure consistent date-to-page mapping.
   final DateTime? minMonth;
 
   /// Determines upper boundary user can scroll.
   ///
-  /// If not provided [CalendarConstants.maxDate] is default.
+  /// If not provided, [CalendarConstants.maxDate] is used.
   final DateTime? maxMonth;
 
   /// Defines initial display month.

--- a/lib/src/multi_day_view/multi_day_view.dart
+++ b/lib/src/multi_day_view/multi_day_view.dart
@@ -25,13 +25,10 @@ class MultiDayView<T extends Object?> extends StatefulWidget {
   /// [CalendarPageHeader] | [DayPageHeader] | [MonthPageHeader] |
   /// [WeekPageHeader] widgets provided by this package with your custom
   /// configurations.
-  ///
   final WeekPageHeaderBuilder? weekPageHeaderBuilder;
 
   /// Builds custom PressDetector widget
-  ///
   /// If null, internal PressDetector will be used to handle onDateLongPress()
-  ///
   final DetectorBuilder? weekDetectorBuilder;
 
   /// This function will generate dateString int the calendar header.
@@ -56,24 +53,13 @@ class MultiDayView<T extends Object?> extends StatefulWidget {
   /// Called whenever user changes week.
   final CalendarPageChangeCallBack? onPageChange;
 
-  /// Minimum day to display in week view.
-  ///
-  /// In calendar first date of the week that contains this data will be
-  /// minimum date.
-  ///
-  /// ex, If minDay is 16th March, 2022 then week containing this date will have
-  /// dates from 14th to 20th (Monday to Sunday). adn 14th date will
-  /// be the actual minimum date.
+  /// Minimum day to display in multi-day view.
+  /// Defaults to [CalendarConstants.epochDate] if not provided.
+  /// Used as base date for page indexing calculation.
   final DateTime? minDay;
 
-  /// Maximum day to display in week view.
-  ///
-  /// In calendar last date of the week that contains this data will be
-  /// maximum date.
-  ///
-  /// ex, If maxDay is 16th March, 2022 then week containing this date will have
-  /// dates from 14th to 20th (Monday to Sunday). adn 20th date will
-  /// be the actual maximum date.
+  /// Maximum day to display in multi-day view.
+  /// Defaults to [CalendarConstants.maxDate] if not provided.
   final DateTime? maxDay;
 
   /// Initial week to display in week view.
@@ -82,8 +68,7 @@ class MultiDayView<T extends Object?> extends StatefulWidget {
   /// Settings for hour indicator settings.
   final HourIndicatorSettings? hourIndicatorSettings;
 
-  /// A funtion that returns a [CustomPainter].
-  ///
+  /// A function that returns a [CustomPainter].
   /// Use this if you want to paint custom hour lines.
   final CustomHourLinePainter? hourLinePainter;
 
@@ -155,27 +140,6 @@ class MultiDayView<T extends Object?> extends StatefulWidget {
   /// Called when user double taps on any event tile.
   final CellTapCallback<T>? onEventDoubleTap;
 
-  /// Show weekends or not
-  ///
-  /// Default value is true.
-  ///
-  /// If it is false week view will remove weekends from week
-  /// even if weekends are added in [weekDays].
-  ///
-  /// ex, if [showWeekends] is false and [weekDays] are monday, tuesday,
-  /// saturday and sunday, only monday and tuesday will be visible in week view.
-  // final bool showWeekends;
-
-  /// Defines which days should be displayed in one week.
-  ///
-  /// By default all the days will be visible.
-  /// Sequence will be monday to sunday.
-  ///
-  /// Duplicate values will be removed from list.
-  ///
-  /// ex, if there are two mondays in list it will display only one.
-  // final List<WeekDays> weekDays;
-
   /// This method will be called when user long press on calendar.
   final DatePressCallback? onDateLongPress;
 
@@ -187,11 +151,6 @@ class MultiDayView<T extends Object?> extends StatefulWidget {
   /// Ex, User Taps on Date page with date 11/01/2022 and time span is 1PM to 2PM.
   /// then DateTime object will be  DateTime(2022,01,11,1,0)
   final DateTapCallback? onDateTap;
-
-  /// Defines the day from which the week starts.
-  ///
-  /// Default value is [WeekDays.monday].
-  // final WeekDays startDay;
 
   /// Defines size of the slots that provides long press callback on area
   /// where events are not there.
@@ -231,7 +190,6 @@ class MultiDayView<T extends Object?> extends StatefulWidget {
   final ScrollPhysics? scrollPhysics;
 
   /// Defines scroll physics for a page of a week view.
-  ///
   /// This can be used to disable the horizontal scroll of a page.
   final ScrollPhysics? pageViewPhysics;
 
@@ -286,9 +244,6 @@ class MultiDayView<T extends Object?> extends StatefulWidget {
     this.onEventLongTap,
     this.onDateLongPress,
     this.onDateTap,
-    // this.weekDays = WeekDays.values,
-    // this.showWeekends = true,
-    // this.startDay = WeekDays.monday,
     this.minuteSlotSize = MinuteSlotSize.minutes60,
     this.weekDetectorBuilder,
     this.headerStringBuilder,
@@ -968,11 +923,11 @@ class MultiDayViewState<T extends Object?> extends State<MultiDayView<T>> {
     widget.onPageChange?.call(_currentStartDate, _currentIndex);
   }
 
-  /// Animate to next page
+  /// Animate to next page (next multi-day period).
   ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
+  /// Transitions with animation using [pageTransitionDuration] and [pageTransitionCurve].
+  ///
+  /// See also: [previousPage], [jumpToWeek], [animateToWeek]
   void nextPage({Duration? duration, Curve? curve}) {
     _pageController.nextPage(
       duration: duration ?? widget.pageTransitionDuration,
@@ -980,11 +935,11 @@ class MultiDayViewState<T extends Object?> extends State<MultiDayView<T>> {
     );
   }
 
-  /// Animate to previous page
+  /// Animate to previous page (previous multi-day period).
   ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
+  /// Transitions with animation using [pageTransitionDuration] and [pageTransitionCurve].
+  ///
+  /// See also: [nextPage], [jumpToWeek], [animateToWeek]
   void previousPage({Duration? duration, Curve? curve}) {
     _pageController.previousPage(
       duration: duration ?? widget.pageTransitionDuration,
@@ -992,16 +947,22 @@ class MultiDayViewState<T extends Object?> extends State<MultiDayView<T>> {
     );
   }
 
-  /// Jumps to page number [page]
+  /// Jumps to page index without animation.
   ///
+  /// **Page Index Formula:** `periodIndex = (periodStartDate - minPeriodStartDate) / daysInView`
+  /// For calculation details, see [jumpToWeek].
   ///
+  /// **Prefer:** Use [jumpToWeek] instead of this method for date-based navigation.
   void jumpToPage(int page) => _pageController.jumpToPage(page);
 
-  /// Animate to page number [page].
+  /// Animates to page index with animation.
   ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
+  /// Arguments [duration] and [curve] override default transition values.
+  ///
+  /// **Page Index Formula:** `periodIndex = (periodStartDate - minPeriodStartDate) / daysInView`
+  /// For calculation details, see [animateToWeek].
+  ///
+  /// **Prefer:** Use [animateToWeek] instead of this method for date-based navigation.
   Future<void> animateToPage(int page,
       {Duration? duration, Curve? curve}) async {
     await _pageController.animateToPage(page,
@@ -1009,7 +970,11 @@ class MultiDayViewState<T extends Object?> extends State<MultiDayView<T>> {
         curve: curve ?? widget.pageTransitionCurve);
   }
 
-  /// Returns current page number.
+  /// Returns current page index (number of periods since [minDay]).
+  ///
+  /// Use [currentDate] to get the period's first date.
+  ///
+  /// See also: [currentDate], [jumpToWeek]
   int get currentPage => _currentIndex;
 
   /// Jumps to page which gives day calendar for [week]

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -25,29 +25,22 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// [CalendarPageHeader] | [DayPageHeader] | [MonthPageHeader] |
   /// [WeekPageHeader] widgets provided by this package with your custom
   /// configurations.
-  ///
   final WeekPageHeaderBuilder? weekPageHeaderBuilder;
 
-  /// Builds custom PressDetector widget
-  ///
-  /// If null, internal PressDetector will be used to handle onDateLongPress()
-  ///
+  /// Builds custom PressDetector widget.
+  /// If null, internal PressDetector handles [onDateLongPress].
   final DetectorBuilder? weekDetectorBuilder;
 
-  /// This function will generate dateString int the calendar header.
-  /// Useful for I18n
+  /// Generates date string in the calendar header. Useful for I18n.
   final StringProvider? headerStringBuilder;
 
-  /// This function will generate the TimeString in the timeline.
-  /// Useful for I18n
+  /// Generates time string in the timeline. Useful for I18n.
   final StringProvider? timeLineStringBuilder;
 
-  /// This function will generate WeekDayString in the weekday.
-  /// Useful for I18n
+  /// Generates week day string. Useful for I18n.
   final String Function(int)? weekDayStringBuilder;
 
-  /// This function will generate WeekDayDateString in the weekday.
-  /// Useful for I18n
+  /// Generates week day date string. Useful for I18n.
   final String Function(int)? weekDayDateStringBuilder;
 
   /// Arrange events.
@@ -56,24 +49,17 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// Called whenever user changes week.
   final CalendarPageChangeCallBack? onPageChange;
 
-  /// Minimum day to display in week view.
+  /// Minimum day to display (base date for page indexing).
   ///
-  /// In calendar first date of the week that contains this data will be
-  /// minimum date.
-  ///
-  /// ex, If minDay is 16th March, 2022 then week containing this date will have
-  /// dates from 14th to 20th (Monday to Sunday). adn 14th date will
-  /// be the actual minimum date.
+  /// The week containing this date will be the minimum week displayed.
+  /// If not provided, [CalendarConstants.epochDate] (1900-01-01) is used.
+  /// Use same [minDay] across all views when switching between them.
   final DateTime? minDay;
 
   /// Maximum day to display in week view.
   ///
-  /// In calendar last date of the week that contains this data will be
-  /// maximum date.
-  ///
-  /// ex, If maxDay is 16th March, 2022 then week containing this date will have
-  /// dates from 14th to 20th (Monday to Sunday). adn 20th date will
-  /// be the actual maximum date.
+  /// The last date of the week containing this date will be the maximum displayed.
+  /// If not provided, [CalendarConstants.maxDate] is used.
   final DateTime? maxDay;
 
   /// Initial week to display in week view.
@@ -82,7 +68,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// Settings for hour indicator settings.
   final HourIndicatorSettings? hourIndicatorSettings;
 
-  /// A funtion that returns a [CustomPainter].
+  /// A function that returns a [CustomPainter].
   ///
   /// Use this if you want to paint custom hour lines.
   final CustomHourLinePainter? hourLinePainter;
@@ -348,59 +334,134 @@ class WeekView<T extends Object?> extends StatefulWidget {
 }
 
 class WeekViewState<T extends Object?> extends State<WeekView<T>> {
+  /// Width of the Week View widget in pixels.
   late double _width;
+
+  /// Total height of the visible week view.
+  /// Calculated as: hourHeight * (endHour - startHour)
   late double _height;
+
+  /// Width allocated for the timeline/hour labels on the left side.
   late double _timeLineWidth;
+
+  /// Height occupied by a single hour in pixels.
+  /// Calculated as: heightPerMinute * 60
   late double _hourHeight;
+
+  /// Last recorded scroll offset position.
   late double _lastScrollOffset;
+
+  /// Start date of the currently displayed week.
   late DateTime _currentStartDate;
+
+  /// End date of the currently displayed week.
   late DateTime _currentEndDate;
+
+  /// Maximum date user can scroll to (aligned to week end).
   late DateTime _maxDate;
+
+  /// Minimum date user can scroll to (reference for page indexing).
+  /// Calculated as: weekIndex = (weekStartDate - minWeekStartDate) / 7
   late DateTime _minDate;
+
+  /// Reference week for page index calculations.
   late DateTime _currentWeek;
+
+  /// Total number of weeks available in the calendar range.
   late int _totalWeeks;
+
+  /// Current page index in the PageView controller.
   late int _currentIndex;
+
+  /// Title text for the full-day events section.
   late String _fullDayHeaderTitle;
 
+  /// Event arrangement strategy for positioning events.
   late EventArranger<T> _eventArranger;
 
+  /// Settings for full hour indicator lines.
   late HourIndicatorSettings _hourIndicatorSettings;
+
+  /// Custom painter for drawing hour lines.
   late CustomHourLinePainter _hourLinePainter;
 
+  /// Settings for half-hour indicator lines.
   late HourIndicatorSettings _halfHourIndicatorSettings;
+
+  /// Settings for the live time indicator.
   late LiveTimeIndicatorSettings _liveTimeIndicatorSettings;
+
+  /// Settings for quarter-hour indicator lines.
   late HourIndicatorSettings _quarterHourIndicatorSettings;
+
+  /// Settings for divider between FullDay events and weekdays header.
   late DividerSettings _dividerSettings;
 
+  /// Builder for adding custom colors to time slots in the day view.
   late TimeSlotColorBuilder? _timeSlotColorBuilder;
 
+  /// Controller for managing page transitions between weeks.
+  /// Used for navigating to different weeks.
   late PageController _pageController;
 
+  /// Builder function for creating timeline/hour labels.
   late DateWidgetBuilder _timeLineBuilder;
+
+  /// Builder function for creating event tiles.
   late EventTileBuilder<T> _eventTileBuilder;
+
+  /// Builder function for creating the week header.
   late WeekPageHeaderBuilder _weekHeaderBuilder;
+
+  /// Builder function for creating week day headers.
   late DateWidgetBuilder _weekDayBuilder;
+
+  /// Builder function for creating week number display.
   late WeekNumberBuilder _weekNumberBuilder;
+
+  /// Builder function for creating full-day event displays.
   late FullDayEventBuilder<T> _fullDayEventBuilder;
+
+  /// Builder function for creating the press detector overlay.
   late DetectorBuilder _weekDetectorBuilder;
+
+  /// Configuration for styling the full-day event header text.
   late FullDayHeaderTextConfig _fullDayHeaderTextConfig;
 
+  /// Width allocated for each day column.
+  /// Calculated as: (totalWidth - timelineWidth) / totalDaysInWeek
   late double _weekTitleWidth;
+
+  /// Number of days in a week (typically 7).
+  /// Used for layout calculations and iteration.
   late int _totalDaysInWeek;
 
+  /// Callback function triggered when events change or rebuild is needed.
   late VoidCallback _reloadCallback;
 
+  /// Event controller for managing calendar events.
+  /// Provides data for rendering events for the week.
   EventController<T>? _controller;
 
+  /// Scroll controller for managing vertical scrolling.
   late ScrollController _scrollController;
 
+  /// Public getter for accessing the scroll controller.
   ScrollController get scrollController => _scrollController;
 
+  /// List of days in a week with their properties (name, order, etc.).
+  /// Used for rendering day headers and determining week layout.
   late List<WeekDays> _weekDays;
 
+  /// First hour to display in the week view (0-23).
+  /// Controls the starting hour of the visible time range.
   late int _startHour;
+
+  /// Last hour to display in the week view (1-24).
+  /// Controls the ending hour of the visible time range.
   late int _endHour;
 
+  /// Configuration for handling scroll events when jumping/animating to specific events.
   final _scrollConfiguration = EventScrollConfiguration();
 
   @override
@@ -734,7 +795,6 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
   ///
   /// If maximum and minimum dates are change then first call _setDateRange
   /// and then _regulateCurrentDate method.
-  ///
   void _regulateCurrentDate() {
     if (_currentWeek.isBefore(_minDate)) {
       _currentWeek = _minDate;
@@ -768,9 +828,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
         _minDate.getWeekDifference(_maxDate, start: widget.startDay) + 1;
   }
 
-  /// Default press detector builder. This builder will be used if
-  /// [widget.weekDetectorBuilder] is null.
-  ///
+  /// Default press detector builder (used if [widget.weekDetectorBuilder] is null).
   Widget _defaultPressDetectorBuilder({
     required DateTime date,
     required double height,
@@ -789,7 +847,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
         startHour: _startHour,
       );
 
-  /// Default builder for week line.
+  /// Default builder for the week day header displaying day name and date.
   Widget _defaultWeekDayBuilder(DateTime date) {
     return Center(
       child: Column(
@@ -833,9 +891,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     );
   }
 
-  /// Default timeline builder this builder will be used if
-  /// [widget.eventTileBuilder] is null
-  ///
+  /// Default timeline builder (used if [widget.eventTileBuilder] is null).
   Widget _defaultTimeLineBuilder(DateTime date) => DefaultTimeLineMark(
         date: date,
         timeStringBuilder: widget.timeLineStringBuilder,
@@ -845,8 +901,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
         ),
       );
 
-  /// Default timeline builder. This builder will be used if
-  /// [widget.eventTileBuilder] is null
+  /// Default event tile builder (used if [widget.eventTileBuilder] is null).
   Widget _defaultEventTileBuilder(
     DateTime date,
     List<CalendarEventData<T>> events,
@@ -862,8 +917,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
         endDuration: endDuration,
       );
 
-  /// Default view header builder. This builder will be used if
-  /// [widget.dayTitleBuilder] is null.
+  /// Default week page header builder (used if [widget.dayTitleBuilder] is null).
   Widget _defaultWeekPageHeaderBuilder(
     DateTime startDate,
     DateTime endDate,
@@ -983,16 +1037,14 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     );
   }
 
-  /// Jumps to page number [page]
-  ///
-  ///
+  /// Jumps to page index without animation.
+  /// Page Index Calculation: weekIndex = (weekStartDate - minWeekStartDate) / 7
+  /// Prefer [jumpToWeek] instead for date-based navigation.
   void jumpToPage(int page) => _pageController.jumpToPage(page);
 
-  /// Animate to page number [page].
-  ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
+  /// Animates to page index with animation.
+  /// Page Index Calculation: weekIndex = (weekStartDate - minWeekStartDate) / 7
+  /// Prefer [animateToWeek] instead for date-based navigation.
   Future<void> animateToPage(int page,
       {Duration? duration, Curve? curve}) async {
     await _pageController.animateToPage(page,
@@ -1000,7 +1052,9 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
         curve: curve ?? widget.pageTransitionCurve);
   }
 
-  /// Returns current page number.
+  /// Returns current page index (number of weeks since [minDay]).
+  ///
+  /// Use [currentDate] to get the week's first date.
   int get currentPage => _currentIndex;
 
   /// Jumps to page which gives day calendar for [week]
@@ -1033,9 +1087,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
   DateTime get currentDate => DateTime(
       _currentStartDate.year, _currentStartDate.month, _currentStartDate.day);
 
-  /// Jumps to page which contains given events and make event
-  /// tile visible to user.
-  ///
+  /// Jumps to page which contains given event and makes tile visible.
   Future<void> jumpToEvent(CalendarEventData<T> event) async {
     jumpToWeek(event.date);
 
@@ -1046,20 +1098,12 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     );
   }
 
-  /// Animate to page which contains given events and make event
-  /// tile visible to user.
-  ///
-  /// Arguments [duration] and [curve] will override default values provided
-  /// as [DayView.pageTransitionDuration] and [DayView.pageTransitionCurve]
-  /// respectively.
-  ///
-  /// Actual duration will be 2 times the given duration.
+  /// Animate to page which contains given events and make event tile visible.
+  /// Actual duration will be 2 times the given duration (animate + scroll).
   ///
   /// Ex, If provided duration is 200 milliseconds then this function will take
   /// 200 milliseconds for animate to page then 200 milliseconds for
   /// scroll to event tile.
-  ///
-  ///
   Future<void> animateToEvent(CalendarEventData<T> event,
       {Duration? duration, Curve? curve}) async {
     await animateToWeek(event.date, duration: duration, curve: curve);
@@ -1083,8 +1127,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
     );
   }
 
-  /// check if any dates contains current date or not.
-  /// Returns true if it does else false.
+  /// Check if any dates contain current date. Returns true if found.
   bool _showLiveTimeIndicator(List<DateTime> dates) {
     final now = _liveTimeIndicatorSettings.currentTimeProvider?.call() ??
         DateTime.now();


### PR DESCRIPTION
# Description

This PR adds and enhances dartdoc comments across `DayView`, `WeekView`, `MonthView`, and `MultiDayView` to address the lack of documentation around how `pageIndex` is related to a date (issue #448).

### What was missing

`jumpToPage()` and `animateToPage()` are exposed on all view states, but no documentation explained how a page index maps to a date. The index is derived from a `minDay`/`minMonth` parameter with view-specific alignment logic (day-difference for `DayView`, week-alignment for `WeekView`, month-difference for `MonthView`, and period-based for `MultiDayView`), making these methods practically unusable without reading the source.

### What changed

- **`DayView` / `DayViewState`**: Documented the page index formula (`pageIndex = date.getDayDifference(minDay)`) on `minDay`, `maxDay`, `jumpToPage`, `animateToPage`, and `currentPage`. Added rich dartdoc to all private state fields. Added code examples to `jumpToDate`, `animateToDate`, `jumpToEvent`, `animateToEvent`, `animateToDuration`, and `animateTo`. Added `See also:` cross-references between related navigation methods.
- **`WeekView` / `WeekViewState`**: Documented the week index formula (`weekIndex = (weekStartDate - minWeekStartDate) / 7`) on `minDay`, `maxDay`, `jumpToPage`, `animateToPage`, and `currentPage`. Documented all private state fields. Added `See also:` cross-references.
- **`MonthView` / `MonthViewState`**: Documented the month index formula (`pageIndex = month.getMonthDifference(minMonth) - 1`) on `minMonth` (in `MonthViewStyle`) and all navigation methods. Documented private state fields.
- **`MultiDayView` / `MultiDayViewState`**: Documented the period index formula on `minDay`, `maxDay`, `jumpToPage`, `animateToPage`, and `currentPage`. Updated description of `minDay`/`maxDay` to be consistent with the new documentation style.

No logic or behavior was changed; this is a documentation-only update.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #448

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org