### PR TITLE
🐛 Update DayViewWidget and WeekViewWidget to use transparent cell colors for theme support

### DIFF
--- a/example/lib/widgets/day_view_widget.dart
+++ b/example/lib/widgets/day_view_widget.dart
@@ -66,7 +66,7 @@ class DayViewWidget extends StatelessWidget {
             ? Colors.orange.shade100
             : isBusinessHours
             ? Colors.green.shade50
-            : Colors.grey.shade50;
+            : Colors.transparent;
       },
       showLiveTimeLineInAllDays: true,
       liveTimeIndicatorSettings: LiveTimeIndicatorSettings(

--- a/example/lib/widgets/week_view_widget.dart
+++ b/example/lib/widgets/week_view_widget.dart
@@ -31,7 +31,7 @@ class WeekViewWidget extends StatelessWidget {
             ? Colors.orange.shade100
             : isBusinessHours
             ? Colors.green.shade50
-            : Colors.grey.shade50;
+            : Colors.transparent;
       },
       eventArranger: SideEventArranger(maxWidth: 30),
       timeLineWidth: 65,


### PR DESCRIPTION
# Description

Fixes theme color visibility issues in the example app's `DayViewWidget` and `WeekViewWidget`.

Previously, cells used a hardcoded background color:

```dart
Colors.grey.shade50
````

This prevented the widgets from properly reflecting the active app theme.
The change replaces the hardcoded color with:

```dart
Colors.transparent
```

allowing the cells to inherit and display theme-based colors correctly.

### Files Updated

* `DayViewWidget`
* `WeekViewWidget`

## Checklist

* [x] The title of my PR starts with a [[Conventional Commit](https://conventionalcommits.org/)] prefix (`fix:`, `feat:`, `docs:` etc).
* [x] I have followed the [[Contributor Guide](https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md)] when preparing my PR.
* [ ] I have updated/added tests for ALL new/updated/fixed functionality.
* [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
* [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

* [ ] Yes, this PR is a breaking change.
* [x] No, this PR is not a breaking change.

## Related Issues

None

## Improvements

| Before | After |
|---|---|
| <img width="300" alt="Before" src="https://github.com/user-attachments/assets/027f6c92-f0ff-4ced-b8dd-dec2479140da" /> | <img width="300" alt="After" src="https://github.com/user-attachments/assets/2aa813e6-fc02-471c-af2b-196461aace26" /> |

