### PR TITLE
🐛 Fix FloatingActionButton heroTag conflicts across views

### DIFF
--- a/example/lib/pages/day_view_page.dart
+++ b/example/lib/pages/day_view_page.dart
@@ -25,6 +25,7 @@ class _DayViewPageDemoState extends State<DayViewPageDemo> {
         primary: false,
         appBar: AppBar(leading: const SizedBox.shrink()),
         floatingActionButton: FloatingActionButton(
+          heroTag: 'add_event_day_view',
           child: Icon(Icons.add, color: appColors.onPrimary),
           elevation: 8,
           onPressed: () => context.pushRoute(CreateEventPage()),

--- a/example/lib/pages/month_view_page.dart
+++ b/example/lib/pages/month_view_page.dart
@@ -25,6 +25,7 @@ class _MonthViewPageDemoState extends State<MonthViewPageDemo> {
         primary: false,
         appBar: AppBar(leading: const SizedBox.shrink()),
         floatingActionButton: FloatingActionButton(
+          heroTag: 'add_event_month_view',
           child: Icon(Icons.add, color: appColors.onPrimary),
           elevation: 8,
           onPressed: () => context.pushRoute(CreateEventPage()),

--- a/example/lib/pages/multi_day_view_page.dart
+++ b/example/lib/pages/multi_day_view_page.dart
@@ -23,6 +23,7 @@ class _MultiDayViewDemoState extends State<MultiDayViewDemo> {
         primary: false,
         appBar: AppBar(leading: const SizedBox.shrink()),
         floatingActionButton: FloatingActionButton(
+          heroTag: 'add_event_multiday_view',
           child: Icon(Icons.add, color: context.appColors.onPrimary),
           elevation: 8,
           onPressed: () => context.pushRoute(CreateEventPage()),

--- a/example/lib/pages/week_view_page.dart
+++ b/example/lib/pages/week_view_page.dart
@@ -42,7 +42,7 @@ class _WeekViewDemoState extends State<WeekViewDemo> {
                           .clamp(_minHeight, _maxHeight),
                     )
                   : null,
-              child: const Icon(Icons.zoom_in),
+              child: Icon(Icons.zoom_in, color: themeColors.onPrimary),
             ),
             const SizedBox(height: 8),
             FloatingActionButton.small(
@@ -54,11 +54,11 @@ class _WeekViewDemoState extends State<WeekViewDemo> {
                           .clamp(_minHeight, _maxHeight),
                     )
                   : null,
-              child: const Icon(Icons.zoom_out),
+              child: Icon(Icons.zoom_out, color: themeColors.onPrimary),
             ),
             const SizedBox(height: 8),
             FloatingActionButton(
-              heroTag: 'add_event',
+              heroTag: 'add_event_week_view',
               child: Icon(Icons.add, color: themeColors.onPrimary),
               elevation: 8,
               onPressed: () => context.pushRoute(CreateEventPage()),

--- a/example/lib/widgets/month_view_widget.dart
+++ b/example/lib/widgets/month_view_widget.dart
@@ -128,6 +128,7 @@ class _MonthViewWidgetState extends State<MonthViewWidget> {
           child: Align(
             alignment: Alignment.centerRight,
             child: FloatingActionButton.small(
+              heroTag: 'clear_selection',
               onPressed: _clearSelection,
               child: Icon(Icons.close, color: context.appColors.onPrimary),
             ),


### PR DESCRIPTION
## Description

This PR fixes a `There are multiple heroes that share the same tag within a subtree` exception occurring in the example application.

The issue was caused by multiple `FloatingActionButton` widgets residing within the same `PageRoute` (subtree) without explicit unique `heroTag` properties. In Flutter, `FloatingActionButton` uses a default hero tag if one isn't provided, and since a page like the `MonthView` had both a primary action FAB and a selection-clearing FAB, a conflict occurred during navigation transitions.

This PR also fixes color theme for zoom in and zoom out icons in FloatingActionButton in `WeekViewPage`.

## Changes

- Assigned unique `heroTag` values to `FloatingActionButton`s in:
  - `example/lib/pages/month_view_page.dart`
  - `example/lib/widgets/month_view_widget.dart`
  - `example/lib/pages/day_view_page.dart`
  - `example/lib/pages/multi_day_view_page.dart`
  - `example/lib/pages/week_view_page.dart`

- Ensured consistency across the example app to prevent similar crashes when navigating between views.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in docs and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in examples or docs.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

None

<!-- Links -->

[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md  
[Conventional Commit]: https://conventionalcommits.org