### PR TITLE
feat: add vertical week mode to WeekView for improved layout and scroll

### DIFF
--- a/example/lib/pages/week_view_page.dart
+++ b/example/lib/pages/week_view_page.dart
@@ -65,7 +65,10 @@ class _WeekViewDemoState extends State<WeekViewDemo> {
             ),
           ],
         ),
-        body: WeekViewWidget(heightPerMinute: _heightPerMinute),
+        body: WeekViewWidget(
+          heightPerMinute: _heightPerMinute,
+          enableVerticalWeekMode: true,
+        ),
       ),
     );
   }

--- a/example/lib/widgets/add_event_form.dart
+++ b/example/lib/widgets/add_event_form.dart
@@ -132,6 +132,8 @@ class _AddOrEditEventFormState extends State<AddOrEditEventForm> {
                   ).applyDefaults(Theme.of(context).inputDecorationTheme),
                   initialDateTime: _startDate,
                   onSelect: (date) {
+                    final previousStartDate = _startDate.withoutTime;
+
                     if (date.withoutTime.withoutTime.isAfter(
                       _endDate.withoutTime,
                     )) {
@@ -140,6 +142,18 @@ class _AddOrEditEventFormState extends State<AddOrEditEventForm> {
 
                     _startDate = date.withoutTime;
                     if (_isRecurring) {
+                      _endDate = _startDate;
+
+                      if (mounted) {
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          setState(() {});
+                        });
+                      }
+                    } else if (_endDate.withoutTime.isAtSameMomentAs(
+                      previousStartDate,
+                    )) {
+                      // Keep single-day events aligned when the user changes
+                      // only start date and has not explicitly changed end date.
                       _endDate = _startDate;
 
                       if (mounted) {
@@ -520,6 +534,29 @@ class _AddOrEditEventFormState extends State<AddOrEditEventForm> {
     if (!(_form.currentState?.validate() ?? true)) return;
 
     _form.currentState?.save();
+
+    final hasOnlyOneTime =
+        (_startTime == null && _endTime != null) ||
+        (_startTime != null && _endTime == null);
+
+    if (hasOnlyOneTime) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please select both start time and end time.'),
+        ),
+      );
+      return;
+    }
+
+    if (_startTime != null &&
+        _endTime != null &&
+        _startDate.withoutTime.isAtSameMomentAs(_endDate.withoutTime) &&
+        _endTime!.getTotalMinutes <= _startTime!.getTotalMinutes) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('End time must be after start time.')),
+      );
+      return;
+    }
 
     DateTime? combinedStartTime;
     DateTime? combinedEndTime;

--- a/example/lib/widgets/calendar_views.dart
+++ b/example/lib/widgets/calendar_views.dart
@@ -26,10 +26,10 @@ class CalendarViews extends StatelessWidget {
       color: AppColors.grey,
       child: Center(
         child: view == CalendarView.month
-            ? MonthViewWidget(width: width)
+            ? MonthViewWidget(width: width, enableVerticalMonthMode: true)
             : view == CalendarView.day
             ? DayViewWidget(width: width)
-            : WeekViewWidget(width: width),
+            : WeekViewWidget(width: width, enableVerticalWeekMode: true),
       ),
     );
   }

--- a/example/lib/widgets/month_view_widget.dart
+++ b/example/lib/widgets/month_view_widget.dart
@@ -8,8 +8,14 @@ import '../pages/event_details_page.dart';
 class MonthViewWidget extends StatefulWidget {
   final GlobalKey<MonthViewState>? state;
   final double? width;
+  final bool enableVerticalMonthMode;
 
-  const MonthViewWidget({super.key, this.state, this.width});
+  const MonthViewWidget({
+    super.key,
+    this.state,
+    this.width,
+    this.enableVerticalMonthMode = false,
+  });
 
   @override
   State<MonthViewWidget> createState() => _MonthViewWidgetState();
@@ -34,6 +40,9 @@ class _MonthViewWidgetState extends State<MonthViewWidget> {
         MonthView(
           key: widget.state,
           width: widget.width,
+          monthViewMode: widget.enableVerticalMonthMode
+              ? MonthViewMode.verticalMonth
+              : MonthViewMode.standard,
           selectedDate: _selectedDate,
           multiDateSelectionRange: _multiSelectedDateRange,
           multiDateSelectionColor: Colors.blue.withValues(alpha: 0.1),

--- a/example/lib/widgets/week_view_widget.dart
+++ b/example/lib/widgets/week_view_widget.dart
@@ -6,6 +6,7 @@ import '../pages/event_details_page.dart';
 class WeekViewWidget extends StatelessWidget {
   final GlobalKey<WeekViewState>? state;
   final double? width;
+  final bool enableVerticalWeekMode;
   final double heightPerMinute;
 
   const WeekViewWidget({
@@ -13,6 +14,7 @@ class WeekViewWidget extends StatelessWidget {
     this.state,
     this.width,
     this.heightPerMinute = 1.0,
+    this.enableVerticalWeekMode = false,
   });
 
   @override
@@ -20,6 +22,14 @@ class WeekViewWidget extends StatelessWidget {
     return WeekView(
       key: state,
       width: width,
+
+      // Set this to WeekViewMode.verticalWeek to enable:
+      // 1) fixed days on the left,
+      // 2) horizontal hour scrolling,
+      // 3) vertical week paging.
+      weekViewMode: enableVerticalWeekMode
+          ? WeekViewMode.verticalWeek
+          : WeekViewMode.standard,
       heightPerMinute: heightPerMinute,
       showWeekends: true,
       showMidnightHour: true,
@@ -69,6 +79,7 @@ class WeekViewWidget extends StatelessWidget {
         SnackBar snackBar = SnackBar(content: Text("on LongTap"));
         ScaffoldMessenger.of(context).showSnackBar(snackBar);
       },
+      weekTitleHeight: 72,
     );
   }
 }

--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -7,6 +7,15 @@ import 'package:flutter/material.dart';
 import '../../calendar_view.dart';
 import '../extensions.dart';
 
+/// Controls how [MonthView] pages are scrolled.
+enum MonthViewMode {
+  /// Existing behavior: month pages scroll horizontally.
+  standard,
+
+  /// Month pages scroll vertically.
+  verticalMonth,
+}
+
 class MonthView<T extends Object?> extends StatefulWidget {
   /// Main [Widget] to display month view.
   const MonthView({
@@ -19,6 +28,7 @@ class MonthView<T extends Object?> extends StatefulWidget {
     this.selectedDate,
     this.multiDateSelectionRange = const {},
     this.multiDateSelectionColor,
+    this.monthViewMode = MonthViewMode.standard,
   }) : super(key: key);
 
   /// A required parameters that controls events for month view.
@@ -57,6 +67,9 @@ class MonthView<T extends Object?> extends StatefulWidget {
 
   /// Color of the date cells selected via [MonthViewBuilders.onDateLongPressMoveUpdate]
   final Color? multiDateSelectionColor;
+
+  /// Controls scroll direction and layout behavior for the month pages.
+  final MonthViewMode monthViewMode;
 
   @override
   MonthViewState<T> createState() => MonthViewState<T>();
@@ -217,21 +230,23 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
     super.dispose();
   }
 
-  void onHorizontalDragEnd(
+  void _onBoundaryDragEnd(
     DragEndDetails dragEndDetails, {
     required bool isFirstPage,
     required bool isLastPage,
+    required Axis scrollDirection,
     TextDirection textDirection = TextDirection.ltr,
   }) {
     final velocity = dragEndDetails.primaryVelocity ?? 0;
     if (velocity == 0) return;
 
     final isRtl = textDirection == TextDirection.rtl;
-
-    // In LTR: swipe right (velocity > 0) = previous, swipe left (velocity < 0) = next
-    // In RTL: swipe right (velocity > 0) = next, swipe left (velocity < 0) = previous
-    final isSwipingToPrevious = isRtl ? velocity < 0 : velocity > 0;
-    final isSwipingToNext = isRtl ? velocity > 0 : velocity < 0;
+    final isSwipingToPrevious = scrollDirection == Axis.horizontal
+        ? (isRtl ? velocity < 0 : velocity > 0)
+        : velocity > 0;
+    final isSwipingToNext = scrollDirection == Axis.horizontal
+        ? (isRtl ? velocity > 0 : velocity < 0)
+        : velocity < 0;
 
     if (isFirstPage && isLastPage) {
       // Only one page - trigger both callbacks based on swipe direction
@@ -281,6 +296,9 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
             ),
             Expanded(
               child: PageView.builder(
+                scrollDirection: widget.monthViewMode == MonthViewMode.standard
+                    ? Axis.horizontal
+                    : Axis.vertical,
                 controller: _pageController,
                 physics: _isMultiDateSelectionInProgress
                     ? const NeverScrollableScrollPhysics()
@@ -370,13 +388,29 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
                     final isFirstPage = index == 0;
                     final isLastPage = index == _totalMonths - 1;
                     if (isFirstPage || isLastPage) {
+                      final axis =
+                          widget.monthViewMode == MonthViewMode.standard
+                              ? Axis.horizontal
+                              : Axis.vertical;
                       return GestureDetector(
-                        onHorizontalDragEnd: (details) => onHorizontalDragEnd(
-                          details,
-                          isFirstPage: isFirstPage,
-                          isLastPage: isLastPage,
-                          textDirection: textDirection,
-                        ),
+                        onHorizontalDragEnd: axis == Axis.horizontal
+                            ? (details) => _onBoundaryDragEnd(
+                                  details,
+                                  isFirstPage: isFirstPage,
+                                  isLastPage: isLastPage,
+                                  scrollDirection: axis,
+                                  textDirection: textDirection,
+                                )
+                            : null,
+                        onVerticalDragEnd: axis == Axis.vertical
+                            ? (details) => _onBoundaryDragEnd(
+                                  details,
+                                  isFirstPage: isFirstPage,
+                                  isLastPage: isLastPage,
+                                  scrollDirection: axis,
+                                  textDirection: textDirection,
+                                )
+                            : null,
                         child: monthPageContent,
                       );
                     }

--- a/lib/src/week_view/_internal_week_view_page.dart
+++ b/lib/src/week_view/_internal_week_view_page.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a MIT-style license
 // that can be found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import '../../calendar_view.dart';
@@ -180,6 +182,9 @@ class InternalWeekViewPage<T extends Object?> extends StatefulWidget {
   /// Default value is false.
   final bool showMidnightHour;
 
+  /// Controls orientation behavior for week view rendering.
+  final WeekViewMode weekViewMode;
+
   /// A single page for week view.
   const InternalWeekViewPage({
     Key? key,
@@ -235,6 +240,7 @@ class InternalWeekViewPage<T extends Object?> extends StatefulWidget {
     this.lastScrollOffset = 0.0,
     this.keepScrollOffset = false,
     this.showMidnightHour = false,
+    this.weekViewMode = WeekViewMode.standard,
   }) : super(key: key);
 
   @override
@@ -244,6 +250,10 @@ class InternalWeekViewPage<T extends Object?> extends StatefulWidget {
 
 class _InternalWeekViewPageState<T extends Object?>
     extends State<InternalWeekViewPage<T>> {
+  static const double _verticalCompactTileHeightThreshold = 60;
+  static const double _verticalCompactTileWidthThreshold = 70;
+  static const double _verticalTinyTileWidthThreshold = 20;
+
   late ZoomScrollController scrollController;
 
   @override
@@ -371,6 +381,10 @@ class _InternalWeekViewPageState<T extends Object?>
     final filteredDates = _filteredDate();
     final themeColor = context.weekViewColors;
     final direction = Directionality.of(context);
+
+    if (widget.weekViewMode == WeekViewMode.verticalWeek) {
+      return _buildVerticalWeekMode(filteredDates, themeColor, direction);
+    }
 
     return Container(
       color: widget.backgroundColor ?? themeColor.pageBackgroundColor,
@@ -688,6 +702,763 @@ class _InternalWeekViewPageState<T extends Object?>
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildVerticalWeekMode(
+    List<DateTime> filteredDates,
+    WeekViewThemeData themeColor,
+    TextDirection direction,
+  ) {
+    if (filteredDates.isEmpty) {
+      return SizedBox.shrink();
+    }
+
+    // Keep each day row equal to one-hour slot height so switching
+    // between standard and vertical modes does not introduce size changes.
+    final rowHeight = widget.hourHeight;
+    final contentHeight = rowHeight * filteredDates.length;
+    final minutesVisible = (widget.endHour - widget.startHour) * 60;
+    final hourContentWidth = minutesVisible * widget.heightPerMinute;
+    final weekdayColumnWidth =
+        widget.timeLineWidth + widget.hourIndicatorSettings.offset;
+    final fullDayColumnWidth = widget.weekTitleWidth;
+    // In vertical mode, timeline thickness follows timeLineWidth because the
+    // time axis becomes horizontal.
+    final timelineBandHeight = widget.timeLineWidth;
+    final rowOffset = timelineBandHeight + widget.hourIndicatorSettings.offset;
+    final totalHeight = rowOffset + contentHeight;
+    final activeController = widget.keepScrollOffset
+        ? scrollController
+        : widget.weekViewScrollController;
+
+    return Container(
+      color: widget.backgroundColor ?? themeColor.pageBackgroundColor,
+      height: totalHeight,
+      width: widget.width,
+      child: Row(
+        children: [
+          SizedBox(
+            width: weekdayColumnWidth,
+            height: totalHeight,
+            child: Column(
+              children: [
+                Container(
+                  height: rowOffset,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: widget.weekTitleBackgroundColor ??
+                        themeColor.weekDayTileColor,
+                    border: Border(
+                      bottom: BorderSide(color: themeColor.borderColor),
+                      right: direction == TextDirection.ltr
+                          ? BorderSide(color: themeColor.borderColor)
+                          : BorderSide.none,
+                      left: direction == TextDirection.rtl
+                          ? BorderSide(color: themeColor.borderColor)
+                          : BorderSide.none,
+                    ),
+                  ),
+                ),
+                ...List.generate(
+                  filteredDates.length,
+                  (index) => _buildVerticalWeekdayColumnCell(
+                    filteredDates[index],
+                    rowHeight,
+                    themeColor,
+                    direction,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: fullDayColumnWidth,
+            height: totalHeight,
+            child: Column(
+              children: [
+                Container(
+                  height: rowOffset,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: widget.weekTitleBackgroundColor ??
+                        themeColor.weekDayTileColor,
+                    border: Border(
+                      bottom: BorderSide(color: themeColor.borderColor),
+                      right: direction == TextDirection.ltr
+                          ? BorderSide(color: themeColor.borderColor)
+                          : BorderSide.none,
+                      left: direction == TextDirection.rtl
+                          ? BorderSide(color: themeColor.borderColor)
+                          : BorderSide.none,
+                    ),
+                  ),
+                ),
+                ...List.generate(
+                  filteredDates.length,
+                  (index) => _buildVerticalFullDayColumnCell(
+                    filteredDates[index],
+                    rowHeight,
+                    themeColor,
+                    direction,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ClipRect(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                controller: activeController,
+                physics: widget.scrollPhysics,
+                child: SizedBox(
+                  width: hourContentWidth,
+                  height: totalHeight,
+                  child: Stack(
+                    children: [
+                      if (widget.timeSlotColorBuilder != null)
+                        _buildVerticalWeekTimeSlotBackgrounds(
+                          filteredDates: filteredDates,
+                          rowHeight: rowHeight,
+                          rowOffset: rowOffset,
+                          hourContentWidth: hourContentWidth,
+                          direction: direction,
+                        ),
+                      ..._buildVerticalHourMarkers(
+                        minutesVisible: minutesVisible,
+                        direction: direction,
+                        themeColor: themeColor,
+                      ),
+                      ..._buildVerticalDayRows(
+                        filteredDates: filteredDates,
+                        rowHeight: rowHeight,
+                        rowOffset: rowOffset,
+                        hourContentWidth: hourContentWidth,
+                        themeColor: themeColor,
+                        direction: direction,
+                      ),
+                      ..._buildVerticalLiveIndicators(
+                        filteredDates: filteredDates,
+                        rowHeight: rowHeight,
+                        rowOffset: rowOffset,
+                        hourContentWidth: hourContentWidth,
+                        themeColor: themeColor,
+                        direction: direction,
+                      ),
+                      // Drawn last so the band renders on top of all rows.
+                      ..._buildHorizontalTimelineIndicators(
+                        filteredDates: filteredDates,
+                        timelineBandHeight: timelineBandHeight,
+                        rowOffset: rowOffset,
+                        hourContentWidth: hourContentWidth,
+                        direction: direction,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildVerticalWeekdayColumnCell(
+    DateTime date,
+    double rowHeight,
+    WeekViewThemeData themeColor,
+    TextDirection direction,
+  ) {
+    return Container(
+      height: rowHeight,
+      decoration: BoxDecoration(
+        color: widget.weekTitleBackgroundColor ?? themeColor.weekDayTileColor,
+        border: Border(
+          right: direction == TextDirection.ltr
+              ? BorderSide(color: themeColor.borderColor)
+              : BorderSide.none,
+          left: direction == TextDirection.rtl
+              ? BorderSide(color: themeColor.borderColor)
+              : BorderSide.none,
+          bottom: BorderSide(color: themeColor.borderColor),
+        ),
+      ),
+      child: SizedBox(
+        height: rowHeight,
+        width: double.infinity,
+        child: widget.weekDayBuilder(date),
+      ),
+    );
+  }
+
+  Widget _buildVerticalFullDayColumnCell(
+    DateTime date,
+    double rowHeight,
+    WeekViewThemeData themeColor,
+    TextDirection direction,
+  ) {
+    final fullDayEventList = widget.controller.getFullDayEvent(date);
+
+    return Container(
+      height: rowHeight,
+      decoration: BoxDecoration(
+        color: widget.backgroundColor ?? themeColor.pageBackgroundColor,
+        border: Border(
+          right: direction == TextDirection.ltr
+              ? BorderSide(color: themeColor.borderColor)
+              : BorderSide.none,
+          left: direction == TextDirection.rtl
+              ? BorderSide(color: themeColor.borderColor)
+              : BorderSide.none,
+          bottom: BorderSide(color: themeColor.borderColor),
+        ),
+      ),
+      child: fullDayEventList.isEmpty
+          ? SizedBox.shrink()
+          : ClipRect(
+              child: SizedBox(
+                height: rowHeight,
+                width: double.infinity,
+                child: widget.fullDayEventBuilder(fullDayEventList, date),
+              ),
+            ),
+    );
+  }
+
+  /// Builds the horizontal hour-label band that runs across the top of the
+  /// scrollable content area in [WeekViewMode.verticalWeek].
+  ///
+  /// The `labelDate` used to construct each [DateTime] passed to
+  /// [timeLineBuilder] is taken from [widget.dates].first — the canonical
+  /// first day of this page's week as computed by [WeekView] before any
+  /// weekend-filtering.  This means:
+  ///
+  /// * The date component correctly advances week-by-week as the user pages
+  ///   through the calendar.
+  /// * Custom [timeLineBuilder] implementations that surface date information
+  ///   (e.g. week-of-year, locale-sensitive month labels) will receive the
+  ///   true week-start date rather than the first *visible* day, which can
+  ///   differ when [WeekView.showWeekends] is false.
+  ///
+  /// Note: only the `hour` field of [labelDate] is varied across the labels;
+  /// the year/month/day stay fixed at the week-start for the whole band.
+  List<Widget> _buildHorizontalTimelineIndicators({
+    required List<DateTime> filteredDates,
+    required double timelineBandHeight,
+    required double rowOffset,
+    required double hourContentWidth,
+    required TextDirection direction,
+  }) {
+    if (timelineBandHeight <= 0) {
+      return const [];
+    }
+
+    final isRtl = direction == TextDirection.rtl;
+
+    // Use the page's canonical week-start date (widget.dates.first) so that
+    // custom timeLineBuilders receive an accurate date regardless of whether
+    // weekends are filtered out of filteredDates.
+    final labelDate =
+        widget.dates.isNotEmpty ? widget.dates.first : DateTime.now();
+    final widgets = <Widget>[
+      Positioned(
+        left: 0,
+        right: 0,
+        top: 0,
+        height: timelineBandHeight,
+        child: ColoredBox(
+          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+          child: SizedBox.expand(),
+        ),
+      ),
+    ];
+
+    final hourCount = widget.endHour - widget.startHour;
+    for (int i = 0; i <= hourCount; i++) {
+      final hour = widget.startHour + i;
+      if (!widget.showMidnightHour && hour == 0) continue;
+
+      final dateTime = DateTime(
+        labelDate.year,
+        labelDate.month,
+        labelDate.day,
+        hour,
+      );
+
+      final offset = i * 60 * widget.heightPerMinute;
+      final labelWidth = math.max(30.0, 60 * widget.heightPerMinute);
+      final anchoredOffset = offset - widget.timeLineOffset;
+
+      widgets.add(
+        Positioned(
+          left: isRtl ? null : anchoredOffset,
+          right: isRtl ? anchoredOffset : null,
+          top: 10,
+          width: labelWidth,
+          height: timelineBandHeight,
+          child: InkWell(
+            onTap: widget.onTimestampTap.safeVoidCall(dateTime),
+            child: widget.timeLineBuilder(dateTime),
+          ),
+        ),
+      );
+    }
+
+    // Full-width divider separating the header band from the day rows.
+    widgets.add(
+      Positioned(
+        left: 0,
+        right: 0,
+        top: rowOffset,
+        child: Divider(
+          height: widget.hourIndicatorSettings.height,
+          thickness: widget.hourIndicatorSettings.height,
+          color: context.weekViewColors.borderColor,
+        ),
+      ),
+    );
+
+    return widgets;
+  }
+
+  Widget _buildVerticalWeekTimeSlotBackgrounds({
+    required List<DateTime> filteredDates,
+    required double rowHeight,
+    required double rowOffset,
+    required double hourContentWidth,
+    required TextDirection direction,
+  }) {
+    final slotMinutes = widget.minuteSlotSize.minutes;
+    final slotWidth = slotMinutes * widget.heightPerMinute;
+    final totalSlots =
+        ((widget.endHour - widget.startHour) * 60) ~/ slotMinutes;
+    final isRtl = direction == TextDirection.rtl;
+
+    return Stack(
+      children: [
+        for (int dayIndex = 0; dayIndex < filteredDates.length; dayIndex++)
+          for (int slotIndex = 0; slotIndex < totalSlots; slotIndex++)
+            Positioned(
+              left: isRtl ? null : slotIndex * slotWidth,
+              right: isRtl ? slotIndex * slotWidth : null,
+              top: rowOffset + dayIndex * rowHeight,
+              width: slotWidth,
+              height: rowHeight,
+              child: ColoredBox(
+                color: widget.timeSlotColorBuilder!(
+                  filteredDates[dayIndex],
+                  _slotDateTime(
+                      filteredDates[dayIndex], slotIndex, slotMinutes),
+                  _slotDateTime(
+                      filteredDates[dayIndex], slotIndex + 1, slotMinutes),
+                  slotIndex,
+                ),
+              ),
+            ),
+      ],
+    );
+  }
+
+  List<Widget> _buildVerticalHourMarkers({
+    required int minutesVisible,
+    required TextDirection direction,
+    required WeekViewThemeData themeColor,
+  }) {
+    final widgets = <Widget>[];
+    final isRtl = direction == TextDirection.rtl;
+
+    final hourCount = widget.endHour - widget.startHour;
+    for (int index = 0; index <= hourCount; index++) {
+      final hour = widget.startHour + index;
+      if (!widget.showMidnightHour && hour == 0) continue;
+
+      final offset = index * 60 * widget.heightPerMinute;
+      widgets.add(
+        Positioned(
+          left: isRtl ? null : offset,
+          right: isRtl ? offset : null,
+          top: 0,
+          bottom: 0,
+          child: Container(
+            width: widget.hourIndicatorSettings.height,
+            color: widget.hourIndicatorSettings.color,
+          ),
+        ),
+      );
+    }
+
+    if (widget.showHalfHours) {
+      for (int index = 0; index < hourCount; index++) {
+        final offset = (index * 60 + 30) * widget.heightPerMinute;
+        widgets.add(
+          Positioned(
+            left: isRtl ? null : offset,
+            right: isRtl ? offset : null,
+            top: 0,
+            bottom: 0,
+            child: Container(
+              width: widget.halfHourIndicatorSettings.height,
+              color: widget.halfHourIndicatorSettings.color,
+            ),
+          ),
+        );
+      }
+    }
+
+    if (widget.showQuarterHours) {
+      for (int index = 0; index < hourCount; index++) {
+        for (final minute in [15, 45]) {
+          final offset = (index * 60 + minute) * widget.heightPerMinute;
+          widgets.add(
+            Positioned(
+              left: isRtl ? null : offset,
+              right: isRtl ? offset : null,
+              top: 0,
+              bottom: 0,
+              child: Container(
+                width: widget.quarterHourIndicatorSettings.height,
+                color: widget.quarterHourIndicatorSettings.color,
+              ),
+            ),
+          );
+        }
+      }
+    }
+
+    return widgets;
+  }
+
+  List<Widget> _buildVerticalDayRows({
+    required List<DateTime> filteredDates,
+    required double rowHeight,
+    required double rowOffset,
+    required double hourContentWidth,
+    required WeekViewThemeData themeColor,
+    required TextDirection direction,
+  }) {
+    final widgets = <Widget>[];
+    final isRtl = direction == TextDirection.rtl;
+
+    for (int index = 0; index < filteredDates.length; index++) {
+      final date = filteredDates[index];
+      final rowTop = rowOffset + rowHeight * index;
+
+      widgets.add(
+        Positioned(
+          left: 0,
+          right: 0,
+          top: rowTop,
+          height: rowHeight,
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTapUp: widget.onDateTap == null
+                ? null
+                : (details) {
+                    widget.onDateTap!.call(_dateFromHorizontalOffset(
+                      date,
+                      details.localPosition.dx,
+                      hourContentWidth,
+                      isRtl,
+                    ));
+                  },
+            onLongPressStart: widget.onDateLongPress == null
+                ? null
+                : (details) {
+                    widget.onDateLongPress!.call(_dateFromHorizontalOffset(
+                      date,
+                      details.localPosition.dx,
+                      hourContentWidth,
+                      isRtl,
+                    ));
+                  },
+            child: SizedBox.expand(),
+          ),
+        ),
+      );
+
+      final arranged = widget.eventArranger.arrange(
+        events: widget.controller.getEventsOnDay(
+          date,
+          includeFullDayEvents: false,
+        ),
+        height: hourContentWidth,
+        width: rowHeight,
+        heightPerMinute: widget.heightPerMinute,
+        startHour: widget.startHour,
+        calendarViewDate: date,
+      );
+
+      for (final organized in arranged) {
+        final eventLeft = organized.top;
+        final eventTop = rowTop + organized.left;
+        final eventWidth = math
+            .max(0.0, hourContentWidth - organized.bottom - organized.top)
+            .toDouble();
+        final eventHeight = math
+            .max(0.0, rowHeight - organized.right - organized.left)
+            .toDouble();
+
+        if (widget.scrollConfiguration.shouldScroll &&
+            organized.events
+                .any((e) => e == widget.scrollConfiguration.event)) {
+          _scrollToHorizontalEvent(eventLeft);
+        }
+
+        widgets.add(
+          Positioned(
+            left: isRtl ? null : eventLeft,
+            right: isRtl ? eventLeft : null,
+            top: eventTop,
+            width: eventWidth,
+            height: eventHeight,
+            child: GestureDetector(
+              onLongPress: widget.onTileLongTap == null
+                  ? null
+                  : () => widget.onTileLongTap!.call(organized.events, date),
+              onTap: widget.onTileTap == null
+                  ? null
+                  : () => widget.onTileTap!.call(organized.events, date),
+              onDoubleTap: widget.onTileDoubleTap == null
+                  ? null
+                  : () => widget.onTileDoubleTap!.call(organized.events, date),
+              child: ClipRect(
+                child: _buildVerticalEventTile(
+                  date: date,
+                  organized: organized,
+                  eventWidth: eventWidth,
+                  eventHeight: eventHeight,
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      widgets.add(
+        Positioned(
+          left: 0,
+          right: 0,
+          top: rowTop,
+          child: Divider(
+            height: widget.hourIndicatorSettings.height,
+            thickness: widget.hourIndicatorSettings.height,
+            color: themeColor.borderColor,
+          ),
+        ),
+      );
+    }
+
+    return widgets;
+  }
+
+  List<Widget> _buildVerticalLiveIndicators({
+    required List<DateTime> filteredDates,
+    required double rowHeight,
+    required double rowOffset,
+    required double hourContentWidth,
+    required WeekViewThemeData themeColor,
+    required TextDirection direction,
+  }) {
+    if (!widget.showLiveLine || widget.liveTimeIndicatorSettings.height <= 0) {
+      return const [];
+    }
+
+    final isRtl = direction == TextDirection.rtl;
+    final now = widget.liveTimeIndicatorSettings.currentTimeProvider?.call() ??
+        DateTime.now();
+    final minuteOffset = now.hour * 60 + now.minute - widget.startHour * 60;
+    final lineX = minuteOffset * widget.heightPerMinute;
+
+    if (lineX < 0 || lineX > hourContentWidth) {
+      return const [];
+    }
+
+    final widgets = <Widget>[];
+    for (int index = 0; index < filteredDates.length; index++) {
+      final date = filteredDates[index];
+      final showOnlyToday = widget.liveTimeIndicatorSettings.onlyShowToday;
+      final showForDate = !showOnlyToday || DateUtils.isSameDay(date, now);
+      if (!showForDate) continue;
+
+      widgets.add(
+        Positioned(
+          left: isRtl ? null : lineX,
+          right: isRtl ? lineX : null,
+          top: rowOffset + rowHeight * index,
+          height: rowHeight,
+          child: Container(
+            width: widget.liveTimeIndicatorSettings.height,
+            color: widget.liveTimeIndicatorSettings.color,
+          ),
+        ),
+      );
+    }
+
+    return widgets;
+  }
+
+  DateTime _slotDateTime(DateTime date, int slotIndex, int slotMinutes) {
+    final minute = widget.startHour * 60 + slotIndex * slotMinutes;
+    return DateTime(
+      date.year,
+      date.month,
+      date.day,
+      minute ~/ 60,
+      minute % 60,
+    );
+  }
+
+  DateTime _dateFromHorizontalOffset(
+    DateTime date,
+    double dx,
+    double hourContentWidth,
+    bool isRtl,
+  ) {
+    // In RTL the time axis is mirrored: dx=0 is the end-hour edge and
+    // dx=hourContentWidth is the start-hour edge, so invert before mapping.
+    final effectiveDx = isRtl ? (hourContentWidth - dx) : dx;
+    final startMinute = widget.startHour * 60;
+    final endMinute = widget.endHour * 60;
+    final tappedMinute =
+        (startMinute + (effectiveDx / widget.heightPerMinute).floor())
+            .clamp(startMinute, endMinute - 1);
+    return DateTime(
+      date.year,
+      date.month,
+      date.day,
+      tappedMinute ~/ 60,
+      tappedMinute % 60,
+    );
+  }
+
+  void _scrollToHorizontalEvent(double targetOffset) {
+    final duration = widget.scrollConfiguration.duration ?? Duration.zero;
+    final curve = widget.scrollConfiguration.curve ?? Curves.ease;
+    final activeController = widget.keepScrollOffset
+        ? scrollController
+        : widget.weekViewScrollController;
+
+    widget.scrollConfiguration.resetScrollEvent();
+
+    ambiguate(WidgetsBinding.instance)?.addPostFrameCallback((_) async {
+      try {
+        await activeController.animateTo(
+          math.max(0, targetOffset - 20),
+          duration: duration,
+          curve: curve,
+        );
+      } finally {
+        widget.scrollConfiguration.completeScroll();
+      }
+    });
+  }
+
+  Widget _buildVerticalEventTile({
+    required DateTime date,
+    required OrganizedCalendarEventData<T> organized,
+    required double eventWidth,
+    required double eventHeight,
+  }) {
+    final useCompactTile = (eventHeight < _verticalCompactTileHeightThreshold ||
+            eventWidth < _verticalCompactTileWidthThreshold) &&
+        organized.events.isNotEmpty;
+
+    if (!useCompactTile) {
+      return widget.eventTileBuilder(
+        date,
+        organized.events,
+        Rect.fromLTWH(0, 0, eventWidth, eventHeight),
+        organized.startDuration,
+        organized.endDuration,
+      );
+    }
+
+    final primaryEvent = organized.events.first;
+    final title = primaryEvent.title.trim();
+    final text = title.isNotEmpty
+        ? title
+        : (primaryEvent.description?.trim().isNotEmpty ?? false)
+            ? primaryEvent.description!.trim()
+            : 'Event';
+    final tinyLabel = text.characters.first;
+
+    if (eventWidth <= _verticalTinyTileWidthThreshold) {
+      return Container(
+        margin: const EdgeInsets.all(0.5),
+        decoration: BoxDecoration(
+          color: primaryEvent.color,
+          borderRadius: BorderRadius.circular(3.0),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          tinyLabel,
+          maxLines: 1,
+          style: TextStyle(
+            color: primaryEvent.color.accent,
+            fontSize: 8,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      );
+    }
+
+    return Container(
+      margin: const EdgeInsets.all(0.5),
+      padding: const EdgeInsets.symmetric(horizontal: 2.0),
+      decoration: BoxDecoration(
+        color: primaryEvent.color,
+        borderRadius: BorderRadius.circular(4.0),
+      ),
+      alignment: Alignment.center,
+      child: Builder(
+        builder: (context) {
+          final textStyle = (primaryEvent.titleStyle ??
+                  TextStyle(
+                    color: primaryEvent.color.accent,
+                    fontSize: 10,
+                    fontWeight: FontWeight.w600,
+                  ))
+              .copyWith(
+            fontSize: 10,
+            overflow: TextOverflow.ellipsis,
+          );
+          final label = Text(
+            text,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            softWrap: false,
+            style: textStyle,
+          );
+          final rotatesToFit = eventWidth < eventHeight;
+
+          if (!rotatesToFit) {
+            return FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: Alignment.centerLeft,
+              child: SizedBox(
+                width: math.max(0.0, eventWidth - 4.0),
+                child: label,
+              ),
+            );
+          }
+
+          final isRtl = Directionality.of(context) == TextDirection.rtl;
+
+          return FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.center,
+            child: RotatedBox(
+              quarterTurns: isRtl ? 1 : 3,
+              child: SizedBox(
+                width: math.max(0.0, eventHeight - 4.0),
+                child: label,
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/src/week_view/week_view.dart
+++ b/lib/src/week_view/week_view.dart
@@ -11,6 +11,16 @@ import '../painters.dart';
 import '../zoom_scroll_controller.dart';
 import '_internal_week_view_page.dart';
 
+/// Controls how [WeekView] lays out days and hours.
+enum WeekViewMode {
+  /// Existing behavior: days laid out horizontally and hours scroll vertically.
+  standard,
+
+  /// Days are fixed on the left, hours scroll horizontally,
+  /// and week pages scroll vertically.
+  verticalWeek,
+}
+
 /// [Widget] to display week view.
 class WeekView<T extends Object?> extends StatefulWidget {
   /// Builder to build tile for events.
@@ -241,6 +251,9 @@ class WeekView<T extends Object?> extends StatefulWidget {
   /// Flag to display the 00:00 (midnight) hour in the timeline.
   final bool showMidnightHour;
 
+  /// Controls WeekView orientation and axis behavior.
+  final WeekViewMode weekViewMode;
+
   /// Main widget for week view.
   const WeekView({
     Key? key,
@@ -305,6 +318,7 @@ class WeekView<T extends Object?> extends StatefulWidget {
     this.onTimestampTap,
     this.timeSlotColorBuilder,
     this.showMidnightHour = false,
+    this.weekViewMode = WeekViewMode.standard,
   })  : assert(!(onHeaderTitleTap != null && weekPageHeaderBuilder != null),
             "can't use [onHeaderTitleTap] & [weekPageHeaderBuilder] simultaneously"),
         assert((timeLineOffset) >= 0,
@@ -642,9 +656,16 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
               ),
               Expanded(
                 child: SizedBox(
-                  height: _height,
+                  height: widget.weekViewMode == WeekViewMode.standard
+                      ? _height
+                      : widget.weekTitleHeight +
+                          (_hourHeight * _totalDaysInWeek),
                   width: _width,
                   child: PageView.builder(
+                    scrollDirection:
+                        widget.weekViewMode == WeekViewMode.standard
+                            ? Axis.horizontal
+                            : Axis.vertical,
                     itemCount: _totalWeeks,
                     controller: _pageController,
                     physics: widget.pageViewPhysics,
@@ -716,6 +737,7 @@ class WeekViewState<T extends Object?> extends State<WeekView<T>> {
                           keepScrollOffset: widget.keepScrollOffset,
                           timeSlotColorBuilder: _timeSlotColorBuilder,
                           showMidnightHour: widget.showMidnightHour,
+                          weekViewMode: widget.weekViewMode,
                         ),
                       );
                     },

--- a/test/week_view_vertical_mode_test.dart
+++ b/test/week_view_vertical_mode_test.dart
@@ -1,0 +1,695 @@
+import 'package:calendar_view/calendar_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns a [WeekView] wrapped in a fixed-size [MaterialApp] / [Scaffold].
+Widget _buildApp({
+  required EventController<Object?> controller,
+  required WeekViewMode weekViewMode,
+  required DateTime initialDay,
+  required DateTime minDay,
+  required DateTime maxDay,
+  bool showWeekends = false,
+  int startHour = 8,
+  int endHour = 12,
+  double timeLineWidth = 64,
+  double heightPerMinute = 1,
+  DateWidgetBuilder? weekDayBuilder,
+  LiveTimeIndicatorSettings? liveTimeIndicatorSettings,
+  TimeSlotColorBuilder? timeSlotColorBuilder,
+  MinuteSlotSize minuteSlotSize = MinuteSlotSize.minutes60,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 600,
+        height: 800,
+        child: WeekView(
+          controller: controller,
+          weekViewMode: weekViewMode,
+          initialDay: initialDay,
+          minDay: minDay,
+          maxDay: maxDay,
+          showWeekends: showWeekends,
+          startHour: startHour,
+          endHour: endHour,
+          timeLineWidth: timeLineWidth,
+          heightPerMinute: heightPerMinute,
+          weekDayBuilder: weekDayBuilder,
+          liveTimeIndicatorSettings: liveTimeIndicatorSettings,
+          timeSlotColorBuilder: timeSlotColorBuilder,
+          minuteSlotSize: minuteSlotSize,
+          // Suppress the full-day header area to keep layout predictable.
+          weekTitleHeight: 0,
+          fullDayHeaderTitle: '',
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  // ─────────────────────────────────────────────────────────────────────────
+  // Group 1 – scroll-axis smoke-tests (kept from original file)
+  // ─────────────────────────────────────────────────────────────────────────
+  group('WeekView mode behavior', () {
+    testWidgets('default (standard) mode uses a horizontal PageView',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 360,
+              height: 640,
+              child: WeekView(
+                controller: EventController(),
+                initialDay: DateTime(2026, 3, 30),
+                minDay: DateTime(2026, 3, 30),
+                maxDay: DateTime(2026, 3, 30),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.scrollDirection, Axis.horizontal);
+    });
+
+    testWidgets(
+        'verticalWeek mode: PageView scrolls vertically and '
+        'inner scroll view is horizontal', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 360,
+              height: 640,
+              child: WeekView(
+                controller: EventController(),
+                initialDay: DateTime(2026, 3, 30),
+                minDay: DateTime(2026, 3, 30),
+                maxDay: DateTime(2026, 3, 30),
+                weekViewMode: WeekViewMode.verticalWeek,
+                showWeekends: false,
+                startHour: 8,
+                endHour: 12,
+                timeLineWidth: 64,
+                weekDayBuilder: (date) => Text('Day ${date.weekday}'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.scrollDirection, Axis.vertical);
+
+      final horizontalScrollViewFinder = find.byWidgetPredicate(
+        (widget) =>
+            widget is SingleChildScrollView &&
+            widget.scrollDirection == Axis.horizontal,
+      );
+      expect(horizontalScrollViewFinder, findsOneWidget);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Group 1b – timeLineBuilder receives correct page date (labelDate fix)
+  // ─────────────────────────────────────────────────────────────────────────
+  group('verticalWeek – timeLineBuilder labelDate semantics', () {
+    testWidgets(
+        'timeLineBuilder receives widget.dates.first so the date advances '
+        'correctly when paging to a different week', (tester) async {
+      // Two full weeks: 2026-03-23 (week 1) and 2026-03-30 (week 2).
+      // The critical check: after paging to week-2 the builder must be called
+      // with dates from the week-2 page (day >= 30), not exclusively week-1.
+      //
+      // Note: PageView pre-builds adjacent pages, so seenDates will contain
+      // dates from *both* weeks after the drag.  We therefore verify that
+      // (a) week-1 dates appeared before the drag, and (b) week-2 dates
+      // appeared after the drag — not that all post-drag dates are week-2.
+      final seenDates = <DateTime>[];
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 600,
+            height: 800,
+            child: WeekView(
+              controller: EventController(),
+              weekViewMode: WeekViewMode.verticalWeek,
+              initialDay: DateTime(2026, 3, 23),
+              minDay: DateTime(2026, 3, 23),
+              maxDay: DateTime(2026, 4, 5),
+              showWeekends: false,
+              startHour: 8,
+              endHour: 10,
+              timeLineWidth: 64,
+              heightPerMinute: 1,
+              weekTitleHeight: 0,
+              fullDayHeaderTitle: '',
+              timeLineBuilder: (dt) {
+                seenDates.add(dt);
+                return Text('${dt.month}/${dt.day} ${dt.hour}h');
+              },
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      // All initial labels must be from the week starting 2026-03-23.
+      expect(seenDates, isNotEmpty);
+      for (final dt in seenDates) {
+        expect(dt.month, 3,
+            reason: 'Week-1 labels should be in March, got $dt');
+        expect(dt.day, greaterThanOrEqualTo(23),
+            reason: 'Week-1 labelDate.day must be >= 23 (Mon), got $dt');
+      }
+
+      // Record count so we can look at only newly-added entries after paging.
+      final countBeforeDrag = seenDates.length;
+
+      // Page forward to week-2 via vertical drag.
+      await tester.drag(find.byType(PageView), const Offset(0, -700));
+      await tester.pumpAndSettle();
+
+      // Collect only the dates that were passed to the builder on the new page.
+      final newDates = seenDates.sublist(countBeforeDrag);
+      expect(newDates, isNotEmpty,
+          reason: 'timeLineBuilder should be called again after paging');
+
+      // At least one label must carry a day from the week-2 page (>= 30).
+      // (PageView may also pre-render week-1 again, which is fine; we just need
+      // evidence that the week-2 page's labelDate was also provided.)
+      expect(
+        newDates.any((dt) => dt.day >= 30),
+        isTrue,
+        reason:
+            'After paging to week-2, at least one label must have day >= 30. '
+            'Got: ${newDates.map((d) => d.day).toSet()}',
+      );
+    });
+
+    testWidgets(
+        'with showWeekends:false the builder receives the canonical '
+        'Monday week-start, not the first visible weekday', (tester) async {
+      // startDay=monday → widget.dates.first is always Monday 2026-03-30.
+      // If the old filteredDates.first were used it would also be Monday in
+      // this config, but this test pins the expectation explicitly so it
+      // catches any regression back to filteredDates.first in configs where
+      // the two differ (e.g. if weekend days appeared before the first
+      // weekday in a custom weekDays list).
+      final seenDays = <int>[];
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 600,
+            height: 800,
+            child: WeekView(
+              controller: EventController(),
+              weekViewMode: WeekViewMode.verticalWeek,
+              initialDay: DateTime(2026, 3, 30),
+              minDay: DateTime(2026, 3, 30),
+              maxDay: DateTime(2026, 4, 5),
+              showWeekends: false,
+              startHour: 8,
+              endHour: 10,
+              timeLineWidth: 64,
+              heightPerMinute: 1,
+              weekTitleHeight: 0,
+              fullDayHeaderTitle: '',
+              timeLineBuilder: (dt) {
+                seenDays.add(dt.day);
+                return Text('${dt.hour}h');
+              },
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      // Every DateTime passed to the builder must carry day == 30.
+      expect(seenDays, isNotEmpty);
+      for (final day in seenDays) {
+        expect(day, 30,
+            reason:
+                'labelDate.day should be 30 (canonical Mon week-start), got $day');
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Group 2 – multi-week vertical paging
+  // ─────────────────────────────────────────────────────────────────────────
+  group('verticalWeek – multi-week paging', () {
+    /// Anchor Monday 2026-03-23.  Using showWeekends:false gives a
+    /// 5-day week (Mon-Fri).  Three full weeks are available.
+    final minDay = DateTime(2026, 3, 23); // week 1 Monday
+    final maxDay = DateTime(2026, 4, 5); // week 3 Sunday (or close)
+
+    testWidgets('PageView covers multiple weeks (at least two pages exist)',
+        (tester) async {
+      await tester.pumpWidget(_buildApp(
+        controller: EventController(),
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: minDay,
+        minDay: minDay,
+        maxDay: maxDay,
+        weekDayBuilder: (d) => Text('WD${d.weekday}'),
+      ));
+      await tester.pump();
+
+      // The PageView itself is present in the tree.
+      expect(find.byType(PageView), findsOneWidget);
+
+      // The first week's Monday label is visible.
+      // (This confirms the page isn't empty and the builder ran.)
+      expect(find.textContaining('WD1'), findsWidgets);
+    });
+
+    testWidgets('vertical drag navigates to second week', (tester) async {
+      // Use distinct weekDayBuilder text so we can tell which week is visible.
+      await tester.pumpWidget(_buildApp(
+        controller: EventController(),
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: minDay,
+        minDay: minDay,
+        maxDay: maxDay,
+        weekDayBuilder: (d) =>
+            Text('${d.month}-${d.day}', key: ValueKey('${d.month}-${d.day}')),
+      ));
+      await tester.pump();
+
+      // Week-1 Monday should be visible.
+      expect(find.text('3-23'), findsOneWidget);
+
+      // Drag the PageView upward to move to the next week page.
+      await tester.drag(find.byType(PageView), const Offset(0, -700));
+      await tester.pumpAndSettle();
+
+      // After paging, week-2 Monday (30 Mar) should appear.
+      expect(find.text('3-30'), findsOneWidget);
+    });
+
+    testWidgets('swiping back restores first week', (tester) async {
+      await tester.pumpWidget(_buildApp(
+        controller: EventController(),
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: minDay,
+        minDay: minDay,
+        maxDay: maxDay,
+        weekDayBuilder: (d) => Text('${d.month}-${d.day}'),
+      ));
+      await tester.pump();
+
+      // Go forward one week.
+      await tester.drag(find.byType(PageView), const Offset(0, -700));
+      await tester.pumpAndSettle();
+
+      // Go back.
+      await tester.drag(find.byType(PageView), const Offset(0, 700));
+      await tester.pumpAndSettle();
+
+      expect(find.text('3-23'), findsOneWidget);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Group 3 – event rendering with SideEventArranger
+  // ─────────────────────────────────────────────────────────────────────────
+  group('verticalWeek – event tiles via SideEventArranger', () {
+    /// Monday 2026-03-30, single week.
+    final weekDay = DateTime(2026, 3, 30);
+
+    testWidgets('non-overlapping events on different days are both rendered',
+        (tester) async {
+      final controller = EventController<Object?>();
+
+      // Event on Monday 09:00–10:00
+      controller.add(CalendarEventData(
+        title: 'Mon Meeting',
+        date: DateTime(2026, 3, 30),
+        startTime: DateTime(2026, 3, 30, 9),
+        endTime: DateTime(2026, 3, 30, 10),
+        color: Colors.blue,
+      ));
+
+      // Event on Wednesday 10:00–11:00
+      controller.add(CalendarEventData(
+        title: 'Wed Workshop',
+        date: DateTime(2026, 4, 1),
+        startTime: DateTime(2026, 4, 1, 10),
+        endTime: DateTime(2026, 4, 1, 11),
+        color: Colors.green,
+      ));
+
+      await tester.pumpWidget(_buildApp(
+        controller: controller,
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: weekDay,
+        minDay: weekDay,
+        maxDay: DateTime(2026, 4, 5),
+        showWeekends: false,
+        startHour: 8,
+        endHour: 12,
+      ));
+      await tester.pump();
+
+      expect(find.text('Mon Meeting'), findsOneWidget);
+      expect(find.text('Wed Workshop'), findsOneWidget);
+    });
+
+    testWidgets('overlapping events on the same day both appear',
+        (tester) async {
+      final controller = EventController<Object?>();
+
+      controller.add(CalendarEventData(
+        title: 'First',
+        date: DateTime(2026, 3, 30),
+        startTime: DateTime(2026, 3, 30, 9),
+        endTime: DateTime(2026, 3, 30, 11),
+        color: Colors.red,
+      ));
+      controller.add(CalendarEventData(
+        title: 'Second',
+        date: DateTime(2026, 3, 30),
+        startTime: DateTime(2026, 3, 30, 10),
+        endTime: DateTime(2026, 3, 30, 12),
+        color: Colors.orange,
+      ));
+
+      await tester.pumpWidget(_buildApp(
+        controller: controller,
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: weekDay,
+        minDay: weekDay,
+        maxDay: DateTime(2026, 4, 5),
+        showWeekends: false,
+        startHour: 8,
+        endHour: 12,
+      ));
+      await tester.pump();
+
+      expect(find.text('First'), findsOneWidget);
+      expect(find.text('Second'), findsOneWidget);
+    });
+
+    testWidgets(
+        'event tile horizontal offset reflects startTime in verticalWeek',
+        (tester) async {
+      // heightPerMinute=1 keeps the layout within the 800px viewport.
+      // The time axis is horizontal in verticalWeek mode, so an event
+      // starting at 09:00 (60 min after startHour=8) should appear to
+      // the right of the weekday/full-day label columns – i.e., dx > 0.
+      final controller = EventController<Object?>();
+      controller.add(CalendarEventData(
+        title: 'PreciseEvent',
+        date: DateTime(2026, 3, 30),
+        startTime: DateTime(2026, 3, 30, 9),
+        endTime: DateTime(2026, 3, 30, 10),
+        color: Colors.purple,
+      ));
+
+      await tester.pumpWidget(_buildApp(
+        controller: controller,
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: weekDay,
+        minDay: weekDay,
+        maxDay: DateTime(2026, 4, 5),
+        showWeekends: false,
+        startHour: 8,
+        endHour: 12,
+        heightPerMinute: 1,
+      ));
+      await tester.pump();
+
+      // The event tile with text 'PreciseEvent' must be found.
+      final tileFinder = find.text('PreciseEvent');
+      expect(tileFinder, findsOneWidget);
+
+      // Verify it is positioned to the right of x=0, confirming the
+      // horizontal time mapping places it inside the scrollable area.
+      final tileLeft = tester.getTopLeft(tileFinder).dx;
+      expect(tileLeft, greaterThan(0));
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Group 4 – live-time indicator in verticalWeek
+  // ─────────────────────────────────────────────────────────────────────────
+  group('verticalWeek – live-time indicator', () {
+    final weekDay = DateTime(2026, 3, 30);
+
+    testWidgets(
+        'live indicator Container is rendered when showLiveLine is true',
+        (tester) async {
+      // Pin "now" inside the visible range so the indicator is definitely
+      // drawn.  startHour=8, endHour=12 → pin at 10:00 on the same day.
+      final fakeNow = DateTime(2026, 3, 30, 10, 0);
+
+      final settings = LiveTimeIndicatorSettings(
+        color: Colors.red,
+        height: 3,
+        currentTimeProvider: () => fakeNow,
+      );
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 600,
+            height: 800,
+            child: WeekView(
+              controller: EventController(),
+              weekViewMode: WeekViewMode.verticalWeek,
+              initialDay: weekDay,
+              minDay: weekDay,
+              maxDay: DateTime(2026, 4, 5),
+              showWeekends: false,
+              startHour: 8,
+              endHour: 12,
+              timeLineWidth: 64,
+              heightPerMinute: 1,
+              showLiveTimeLineInAllDays: true,
+              liveTimeIndicatorSettings: settings,
+              weekTitleHeight: 0,
+              fullDayHeaderTitle: '',
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      // In verticalWeek mode _buildVerticalLiveIndicators places a Container
+      // with color=settings.color for each day row.
+      final redContainers = find.byWidgetPredicate(
+        (w) => w is Container && w.color == Colors.red,
+      );
+      expect(redContainers, findsWidgets);
+    });
+
+    testWidgets('live indicator is absent when height is 0', (tester) async {
+      final fakeNow = DateTime(2026, 3, 30, 10, 0);
+
+      final settings = LiveTimeIndicatorSettings(
+        color: Colors.red,
+        height: 0,
+        currentTimeProvider: () => fakeNow,
+      );
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 600,
+            height: 800,
+            child: WeekView(
+              controller: EventController(),
+              weekViewMode: WeekViewMode.verticalWeek,
+              initialDay: weekDay,
+              minDay: weekDay,
+              maxDay: DateTime(2026, 4, 5),
+              showWeekends: false,
+              startHour: 8,
+              endHour: 12,
+              timeLineWidth: 64,
+              heightPerMinute: 1,
+              showLiveTimeLineInAllDays: true,
+              liveTimeIndicatorSettings: settings,
+              weekTitleHeight: 0,
+              fullDayHeaderTitle: '',
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      // No red Container should be produced by the live indicator.
+      final redContainers = find.byWidgetPredicate(
+        (w) => w is Container && w.color == Colors.red,
+      );
+      expect(redContainers, findsNothing);
+    });
+
+    testWidgets(
+        'live indicator out of [startHour, endHour] range is not rendered',
+        (tester) async {
+      // "now" is before startHour — indicator should be suppressed.
+      final fakeNow = DateTime(2026, 3, 30, 6, 0);
+
+      final settings = LiveTimeIndicatorSettings(
+        color: Colors.red,
+        height: 3,
+        currentTimeProvider: () => fakeNow,
+      );
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 600,
+            height: 800,
+            child: WeekView(
+              controller: EventController(),
+              weekViewMode: WeekViewMode.verticalWeek,
+              initialDay: weekDay,
+              minDay: weekDay,
+              maxDay: DateTime(2026, 4, 5),
+              showWeekends: false,
+              startHour: 8,
+              endHour: 12,
+              timeLineWidth: 64,
+              heightPerMinute: 1,
+              showLiveTimeLineInAllDays: true,
+              liveTimeIndicatorSettings: settings,
+              weekTitleHeight: 0,
+              fullDayHeaderTitle: '',
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      final redContainers = find.byWidgetPredicate(
+        (w) => w is Container && w.color == Colors.red,
+      );
+      expect(redContainers, findsNothing);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Group 5 – timeSlotColorBuilder in verticalWeek
+  // ─────────────────────────────────────────────────────────────────────────
+  group('verticalWeek – timeSlotColorBuilder', () {
+    final weekDay = DateTime(2026, 3, 30);
+
+    testWidgets('builder is called with correct slot boundaries',
+        (tester) async {
+      // startHour=8, endHour=10, minuteSlotSize=60 min  →  2 slots per day
+      // showWeekends=false  →  5 days  →  10 total calls per pump cycle.
+      final slotStarts = <DateTime>[];
+      final slotEnds = <DateTime>[];
+
+      await tester.pumpWidget(_buildApp(
+        controller: EventController(),
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: weekDay,
+        minDay: weekDay,
+        maxDay: DateTime(2026, 4, 5),
+        showWeekends: false,
+        startHour: 8,
+        endHour: 10,
+        minuteSlotSize: MinuteSlotSize.minutes60,
+        timeSlotColorBuilder: (date, slotStart, slotEnd, index) {
+          slotStarts.add(slotStart);
+          slotEnds.add(slotEnd);
+          return Colors.transparent;
+        },
+      ));
+      await tester.pump();
+
+      // Each of the 5 visible days has 2 one-hour slots.
+      final uniqueStarts = slotStarts.toSet();
+      // Slots 08:00 and 09:00 for each day.
+      expect(
+        uniqueStarts.any((dt) => dt.hour == 8 && dt.minute == 0),
+        isTrue,
+        reason: 'Expected a slot starting at 08:00',
+      );
+      expect(
+        uniqueStarts.any((dt) => dt.hour == 9 && dt.minute == 0),
+        isTrue,
+        reason: 'Expected a slot starting at 09:00',
+      );
+
+      final uniqueEnds = slotEnds.toSet();
+      expect(
+        uniqueEnds.any((dt) => dt.hour == 10 && dt.minute == 0),
+        isTrue,
+        reason: 'Expected a slot ending at 10:00',
+      );
+    });
+
+    testWidgets('ColoredBox widgets are created for each visible slot',
+        (tester) async {
+      // 2 hours / 30-min slots = 4 slots per day × 5 days = 20 ColoredBoxes
+      // (one per slot in _buildVerticalWeekTimeSlotBackgrounds).
+      await tester.pumpWidget(_buildApp(
+        controller: EventController(),
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: weekDay,
+        minDay: weekDay,
+        maxDay: DateTime(2026, 4, 5),
+        showWeekends: false,
+        startHour: 8,
+        endHour: 10,
+        minuteSlotSize: MinuteSlotSize.minutes30,
+        timeSlotColorBuilder: (date, slotStart, slotEnd, index) =>
+            index.isEven ? Colors.blue.shade50 : Colors.transparent,
+      ));
+      await tester.pump();
+
+      // At least one ColoredBox must have been painted.
+      expect(find.byType(ColoredBox), findsWidgets);
+    });
+
+    testWidgets('slot index increments monotonically within a day',
+        (tester) async {
+      // Collect (day, slotIndex) pairs to verify index sequence.
+      final indexByDay = <DateTime, List<int>>{};
+
+      await tester.pumpWidget(_buildApp(
+        controller: EventController(),
+        weekViewMode: WeekViewMode.verticalWeek,
+        initialDay: weekDay,
+        minDay: weekDay,
+        maxDay: DateTime(2026, 4, 5),
+        showWeekends: false,
+        startHour: 8,
+        endHour: 11,
+        minuteSlotSize: MinuteSlotSize.minutes60,
+        timeSlotColorBuilder: (date, slotStart, slotEnd, index) {
+          indexByDay.putIfAbsent(date, () => []).add(index);
+          return Colors.transparent;
+        },
+      ));
+      await tester.pump();
+
+      for (final entry in indexByDay.entries) {
+        final indices = entry.value;
+        // Indices must be in strictly ascending order (0, 1, 2, …).
+        for (int i = 1; i < indices.length; i++) {
+          expect(
+            indices[i],
+            greaterThan(indices[i - 1]),
+            reason: 'Slot indices for day ${entry.key} are not monotonic',
+          );
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

This pull request introduces significant enhancements to the calendar view widgets, adding vertical scrolling modes for both month and week views, improving event form validation, and updating the example app to showcase these features. The changes are grouped below by theme.

**Vertical Scrolling Modes for Calendar Views**

* Introduced `MonthViewMode` and `WeekViewMode` enums to control the scroll direction and layout behavior for `MonthView` and `WeekView` widgets, enabling both standard (horizontal) and vertical modes. [[1]](diffhunk://#diff-142d76e7233a96a27fd83656dd2f9e6088b413e63d1ad95b2f4ff4284ef59a67R10-R18) [[2]](diffhunk://#diff-047a0e2d63276a976b9b2805f74a1106470f77cb2711dabbc9d6656ef8a1b695R14-R23)
* Updated `MonthView` and `WeekView` to accept new mode parameters, and adjusted their internal logic to handle vertical page scrolling and layout accordingly. This includes dynamic setting of `PageView` scroll direction and drag gesture handling. [[1]](diffhunk://#diff-142d76e7233a96a27fd83656dd2f9e6088b413e63d1ad95b2f4ff4284ef59a67R31) [[2]](diffhunk://#diff-142d76e7233a96a27fd83656dd2f9e6088b413e63d1ad95b2f4ff4284ef59a67R71-R72) [[3]](diffhunk://#diff-142d76e7233a96a27fd83656dd2f9e6088b413e63d1ad95b2f4ff4284ef59a67L220-R250) [[4]](diffhunk://#diff-142d76e7233a96a27fd83656dd2f9e6088b413e63d1ad95b2f4ff4284ef59a67R300-R302) [[5]](diffhunk://#diff-142d76e7233a96a27fd83656dd2f9e6088b413e63d1ad95b2f4ff4284ef59a67R392-R414) [[6]](diffhunk://#diff-047a0e2d63276a976b9b2805f74a1106470f77cb2711dabbc9d6656ef8a1b695R254-R256) [[7]](diffhunk://#diff-047a0e2d63276a976b9b2805f74a1106470f77cb2711dabbc9d6656ef8a1b695R321) [[8]](diffhunk://#diff-047a0e2d63276a976b9b2805f74a1106470f77cb2711dabbc9d6656ef8a1b695L645-R667) [[9]](diffhunk://#diff-047a0e2d63276a976b9b2805f74a1106470f77cb2711dabbc9d6656ef8a1b695R739)

**Example App Updates**

* Modified the example app to demonstrate the new vertical modes: passed `enableVerticalMonthMode` and `enableVerticalWeekMode` flags to the respective widgets, and updated the UI to reflect the new behaviors. [[1]](diffhunk://#diff-ea40c53804150b1ff2f1c776bb3739f5b7c75bd2c376363bb4831d915607e975R11-R18) [[2]](diffhunk://#diff-ea40c53804150b1ff2f1c776bb3739f5b7c75bd2c376363bb4831d915607e975R43-R45) [[3]](diffhunk://#diff-317cab61a95afee4402f3d85f22f283cef005d3b895e8a5e7aadb82ee7a0e4eaR9-R32) [[4]](diffhunk://#diff-317cab61a95afee4402f3d85f22f283cef005d3b895e8a5e7aadb82ee7a0e4eaR82) [[5]](diffhunk://#diff-bddaacc8df2adfeeab334e2f79a51d73f186dddbc8c46fac192fa1deb4871f5eL29-R32) [[6]](diffhunk://#diff-064cbd1f031c8e1a19964c213c2c1cd12fe9a2fd6db57b89ac4af88a757de429L33-R33) [[7]](diffhunk://#diff-0d20f89eb86da7a97250927f2d60a1afe270d0577cb1d090842a623413a53425L68-R71)
* Added a custom `titleStyle` for demonstration in the home page.

**Event Form Validation Improvements**

* Improved validation in the event creation form to ensure both start and end times are selected, and that end time is after start time for single-day events. Displays appropriate error messages using `SnackBar`.
* Enhanced logic to keep single-day events aligned when only the start date is changed, and to update the UI correctly for recurring events. [[1]](diffhunk://#diff-ec80800203aea018c9b68125e57405072c8f8ea4b011698ef3386fe409029a16R135-R136) [[2]](diffhunk://#diff-ec80800203aea018c9b68125e57405072c8f8ea4b011698ef3386fe409029a16R147-R158)

**Testing**

* Added a new test file `week_view_vertical_mode_test.dart` to verify correct behavior of the new vertical mode in `WeekView`, ensuring scroll direction and layout are as expected.…lling

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/issues/222
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
