### PR TITLE
fix(event-data): treat exactly-midnight end as exclusive end date

### DIFF
--- a/lib/src/calendar_event_data.dart
+++ b/lib/src/calendar_event_data.dart
@@ -59,7 +59,22 @@ class CalendarEventData<T extends Object?> {
   })  : _endDate = endDate?.withoutTime,
         date = date.withoutTime;
 
-  DateTime get endDate => _endDate ?? date;
+  DateTime get endDate {
+    final end = _endDate ?? date;
+
+    // An event whose [endTime] is exactly midnight contributes zero minutes
+    // to the end day, so the end date is exclusive. Full-day events
+    // (null times, or both times at day start) keep the inclusive semantics.
+    if (end.isAfter(date) &&
+        startTime != null &&
+        endTime != null &&
+        endTime!.isDayStart &&
+        !startTime!.isDayStart) {
+      return DateTime(end.year, end.month, end.day - 1);
+    }
+
+    return end;
+  }
 
   /// If this flag returns true that means event is occurring on multiple
   /// days and is not a full day event.

--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -176,7 +176,7 @@ class InternalDayViewPage<T extends Object?> extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _InternalWeekViewPageState<T> createState() => _InternalWeekViewPageState<T>();
+  _InternalDayViewPageState<T> createState() => _InternalDayViewPageState<T>();
 }
 
 class _InternalDayViewPageState<T extends Object?>

--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -176,7 +176,7 @@ class InternalDayViewPage<T extends Object?> extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _InternalDayViewPageState<T> createState() => _InternalDayViewPageState();
+  _InternalWeekViewPageState<T> createState() => _InternalWeekViewPageState<T>();
 }
 
 class _InternalDayViewPageState<T extends Object?>

--- a/test/midnight_end_date_test.dart
+++ b/test/midnight_end_date_test.dart
@@ -1,0 +1,120 @@
+import 'package:calendar_view/calendar_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Events ending exactly at midnight', () {
+    test('shift ending at 12:00 AM does not occur on the next day', () {
+      // Shift: 07/12 4:00 PM -> 07/13 12:00 AM (midnight).
+      final start = DateTime(2026, 7, 12, 16, 0, 0);
+      final end = DateTime(2026, 7, 13, 0, 0, 0);
+
+      final event = CalendarEventData<Object?>(
+        title: 'shift',
+        date: start,
+        endDate: end,
+        startTime: start,
+        endTime: end,
+      );
+
+      expect(event.occursOnDate(DateTime(2026, 7, 12)), isTrue);
+      expect(event.occursOnDate(DateTime(2026, 7, 13)), isFalse);
+      expect(event.isRangingEvent, isFalse);
+      expect(event.endDate, DateTime(2026, 7, 12));
+    });
+
+    test('controller does not return midnight-ending shift on next day', () {
+      final start = DateTime(2026, 7, 12, 16, 0, 0);
+      final end = DateTime(2026, 7, 13, 0, 0, 0);
+
+      final controller = EventController<Object?>();
+      controller.add(CalendarEventData<Object?>(
+        title: 'shift',
+        date: start,
+        endDate: end,
+        startTime: start,
+        endTime: end,
+      ));
+
+      expect(controller.getEventsOnDay(DateTime(2026, 7, 12)), hasLength(1));
+      expect(controller.getEventsOnDay(DateTime(2026, 7, 13)), isEmpty);
+    });
+
+    test('genuine overnight shift still occurs on both days', () {
+      // Shift: 07/12 8:00 PM -> 07/13 4:00 AM.
+      final start = DateTime(2026, 7, 12, 20, 0, 0);
+      final end = DateTime(2026, 7, 13, 4, 0, 0);
+
+      final event = CalendarEventData<Object?>(
+        title: 'overnight',
+        date: start,
+        endDate: end,
+        startTime: start,
+        endTime: end,
+      );
+
+      expect(event.occursOnDate(DateTime(2026, 7, 12)), isTrue);
+      expect(event.occursOnDate(DateTime(2026, 7, 13)), isTrue);
+      expect(event.isRangingEvent, isTrue);
+    });
+
+    test('multi-day shift ending at midnight excludes only the end day', () {
+      // Shift: 07/10 4:00 PM -> 07/12 12:00 AM (midnight).
+      final start = DateTime(2026, 7, 10, 16, 0, 0);
+      final end = DateTime(2026, 7, 12, 0, 0, 0);
+
+      final event = CalendarEventData<Object?>(
+        title: 'long shift',
+        date: start,
+        endDate: end,
+        startTime: start,
+        endTime: end,
+      );
+
+      expect(event.occursOnDate(DateTime(2026, 7, 10)), isTrue);
+      expect(event.occursOnDate(DateTime(2026, 7, 11)), isTrue);
+      expect(event.occursOnDate(DateTime(2026, 7, 12)), isFalse);
+    });
+
+    test('full-day event keeps inclusive end date semantics', () {
+      final event = CalendarEventData<Object?>(
+        title: 'full day',
+        date: DateTime(2026, 7, 12),
+        endDate: DateTime(2026, 7, 13),
+        startTime: DateTime(2026, 7, 12, 0, 0, 0),
+        endTime: DateTime(2026, 7, 13, 0, 0, 0),
+      );
+
+      expect(event.isFullDayEvent, isTrue);
+      expect(event.endDate, DateTime(2026, 7, 13));
+    });
+
+    test('date-only multi-day event keeps inclusive end date semantics', () {
+      // No startTime/endTime — endDate is a plain inclusive calendar date.
+      final event = CalendarEventData<Object?>(
+        title: 'conference',
+        date: DateTime(2026, 7, 10),
+        endDate: DateTime(2026, 7, 13),
+      );
+
+      expect(event.occursOnDate(DateTime(2026, 7, 13)), isTrue);
+      expect(event.endDate, DateTime(2026, 7, 13));
+    });
+
+    test('midnight end on first day of month rolls back correctly', () {
+      // Shift: 07/31 4:00 PM -> 08/01 12:00 AM.
+      final start = DateTime(2026, 7, 31, 16, 0, 0);
+      final end = DateTime(2026, 8, 1, 0, 0, 0);
+
+      final event = CalendarEventData<Object?>(
+        title: 'month boundary shift',
+        date: start,
+        endDate: end,
+        startTime: start,
+        endTime: end,
+      );
+
+      expect(event.endDate, DateTime(2026, 7, 31));
+      expect(event.occursOnDate(DateTime(2026, 8, 1)), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

A shift/event ending at exactly 12:00 AM parses to midnight of the *next* day. `CalendarEventData` stripped the time (`endDate.withoutTime`), so `occursOnDate` and `isRangingEvent` counted the next day as occupied — `MonthView` rendered a phantom event chip on a day the event doesn't actually touch (0 minutes).

Seen in onewell's DSP schedule calendar; affects every MonthView fed midnight-ending events in both onewell and pahm.

## Fix

Normalize in the `endDate` getter: when the event has real start/end times, spans days, and `endTime` is exactly day-start, roll the effective end date back one day.

Explicitly guarded so behavior is unchanged for:
- normal same-day events
- genuine overnight events (e.g. 8 PM → 4 AM still shows on both days)
- full-day events (both times at day start, or null times)
- date-only inclusive `endDate` callers (the documented package semantic)

## Verification

New `test/midnight_end_date_test.dart` (7 cases): 4 fail on master, all 7 pass with this change. Full suite: no new failures (the 2 `custom_sort_test` failures are pre-existing on master).

⚠️ Please use a **merge commit** (not squash) so commit `8a3ab9b` stays reachable — the apps' pubspecs pin it via `ref:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)